### PR TITLE
#26: Update Stride Demo to fennecs 0.5.11-beta and Stride 4.2.0.2232

### DIFF
--- a/demos/stride/Cubes/Cubes.csproj
+++ b/demos/stride/Cubes/Cubes.csproj
@@ -7,16 +7,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Stride.Engine" Version="4.2.0.2067" />
-
-        <PackageReference Include="Stride.Video" Version="4.2.0.2067" />
-        <PackageReference Include="Stride.Physics" Version="4.2.0.2067" />
-        <PackageReference Include="Stride.Navigation" Version="4.2.0.2067" />
-        <PackageReference Include="Stride.Particles" Version="4.2.0.2067" />
-        <PackageReference Include="Stride.UI" Version="4.2.0.2067" />
-
-        <PackageReference Include="Stride.Core.Assets.CompilerApp" Version="4.2.0.2067" IncludeAssets="build;buildTransitive" />
-        <PackageReference Include="fennecs" Version="0.1.0-beta" />
+		<PackageReference Include="Stride.Engine" Version="4.2.0.2232" />
+		<PackageReference Include="Stride.Video" Version="4.2.0.2232" />
+		<PackageReference Include="Stride.Physics" Version="4.2.0.2232" />
+		<PackageReference Include="Stride.Navigation" Version="4.2.0.2232" />
+		<PackageReference Include="Stride.Particles" Version="4.2.0.2232" />
+		<PackageReference Include="Stride.UI" Version="4.2.0.2232" />
+		<PackageReference Include="Stride.Core.Assets.CompilerApp" Version="4.2.0.2232" IncludeAssets="build;buildTransitive" />
+		<PackageReference Include="fennecs" Version="0.5.11-beta" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Brings Stride demo to latest versions:
- Update to fennecs 0.5.11-beta
- Update to Stride 4.2.0.2232

Fixes #26

> [!NOTE]
> The Stride demo uses the font `Bai Jamjuree`, but this isn't a pre-installed font.
> Would it be OK to replace it with `Arial` to give new comers (like me 😅) a "checkout-and-run" experience?