### PR TITLE
feat: round-robin work packaging and scheduler optimizations

### DIFF
--- a/src/fennecs.benchmarks/ECS/CoreFilteredRunnerBenchmarks.cs
+++ b/src/fennecs.benchmarks/ECS/CoreFilteredRunnerBenchmarks.cs
@@ -1,0 +1,66 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Order;
+
+using fennecs;
+
+namespace Benchmark.ECS;
+
+/// <summary>
+/// Compares manual branching with FilteredStream predicate dispatch and filtered Job orchestration.
+/// </summary>
+[ShortRunJob]
+[MemoryDiagnoser]
+[ThreadingDiagnoser]
+[Orderer(SummaryOrderPolicy.FastestToSlowest)]
+[HideColumns("Job", "Error", "RatioSD")]
+public class CoreFilteredRunnerBenchmarks
+{
+    private struct Item
+    {
+        public int Bucket;
+        public int Value;
+    }
+
+    [Params(0, 1, 50, 100)]
+    public int SelectivityPercent { get; set; }
+
+    private const int EntityCount = 100_000;
+
+    private World _world = null!;
+    private Stream<Item> _stream;
+    private FilteredStream<Item> _filtered;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _world = new(EntityCount);
+        using var template = _world.Template().Needs<Item>();
+        template.Spawn(EntityCount, i => new Item { Bucket = i % 100 });
+
+        _stream = _world.Query<Item>().Stream();
+        _filtered = _stream.Where(Passes);
+    }
+
+    private bool Passes(in Item item) => item.Bucket < SelectivityPercent;
+
+    [GlobalCleanup]
+    public void Cleanup() => _world.Dispose();
+
+    [Benchmark(Baseline = true)]
+    public void Manual_For() => _stream.For(SelectivityPercent, static (int threshold, ref Item item) =>
+    {
+        if (item.Bucket < threshold) item.Value++;
+    });
+
+    [Benchmark]
+    public void Filtered_For() => _filtered.For(static (ref Item item) => item.Value++);
+
+    [Benchmark]
+    public void Manual_Job() => _stream.Job(SelectivityPercent, static (int threshold, ref Item item) =>
+    {
+        if (item.Bucket < threshold) item.Value++;
+    });
+
+    [Benchmark]
+    public void Filtered_Job() => _filtered.Job(static (ref Item item) => item.Value++);
+}

--- a/src/fennecs.benchmarks/ECS/CoreJobSchedulingBenchmarks.cs
+++ b/src/fennecs.benchmarks/ECS/CoreJobSchedulingBenchmarks.cs
@@ -38,15 +38,17 @@ public class CoreJobSchedulingBenchmarks
         for (var i = 0; i < targets.Length; i++) targets[i] = _world.Spawn();
 
         var entitiesPerArchetype = EntityCount / ArchetypeCount;
+        var remainder = EntityCount % ArchetypeCount;
         for (var i = 0; i < targets.Length; i++)
         {
             using var template = _world.Template()
                 .Add(new Counter())
                 .Add(new Fragment(), targets[i]);
-            template.Spawn(entitiesPerArchetype);
+            template.Spawn(entitiesPerArchetype + (i < remainder ? 1 : 0));
         }
 
         _stream = _world.Query<Counter>().Stream();
+        if (_stream.Count != EntityCount) throw new InvalidOperationException("Benchmark entity count mismatch.");
     }
 
     [GlobalCleanup]

--- a/src/fennecs.benchmarks/ECS/CoreJobSchedulingBenchmarks.cs
+++ b/src/fennecs.benchmarks/ECS/CoreJobSchedulingBenchmarks.cs
@@ -1,0 +1,66 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Order;
+
+using fennecs;
+
+namespace Benchmark.ECS;
+
+/// <summary>
+/// Tracks the For/Job crossover and work-item growth as matching archetypes become fragmented.
+/// </summary>
+[ShortRunJob]
+[MemoryDiagnoser]
+[ThreadingDiagnoser]
+[Orderer(SummaryOrderPolicy.FastestToSlowest)]
+[HideColumns("Job", "Error", "RatioSD")]
+public class CoreJobSchedulingBenchmarks
+{
+    private struct Counter
+    {
+        public int Value;
+    }
+
+    private record struct Fragment;
+
+    [Params(1, 64, 1024)]
+    public int ArchetypeCount { get; set; }
+
+    private const int EntityCount = 131_072;
+
+    private World _world = null!;
+    private Stream<Counter> _stream;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _world = new(EntityCount + ArchetypeCount);
+        var targets = new Entity[ArchetypeCount];
+        for (var i = 0; i < targets.Length; i++) targets[i] = _world.Spawn();
+
+        var entitiesPerArchetype = EntityCount / ArchetypeCount;
+        for (var i = 0; i < targets.Length; i++)
+        {
+            using var template = _world.Template()
+                .Add(new Counter())
+                .Add(new Fragment(), targets[i]);
+            template.Spawn(entitiesPerArchetype);
+        }
+
+        _stream = _world.Query<Counter>().Stream();
+    }
+
+    [GlobalCleanup]
+    public void Cleanup() => _world.Dispose();
+
+    [Benchmark(Baseline = true)]
+    public void For_NoOp() => _stream.For(static (ref Counter _) => { });
+
+    [Benchmark]
+    public void Job_NoOp() => _stream.Job(static (ref Counter _) => { });
+
+    [Benchmark]
+    public void For_LightWrite() => _stream.For(static (ref Counter counter) => counter.Value++);
+
+    [Benchmark]
+    public void Job_LightWrite() => _stream.Job(static (ref Counter counter) => counter.Value++);
+}

--- a/src/fennecs.benchmarks/ECS/CoreStreamBindingBenchmarks.cs
+++ b/src/fennecs.benchmarks/ECS/CoreStreamBindingBenchmarks.cs
@@ -39,6 +39,7 @@ public class CoreStreamBindingBenchmarks
         for (var i = 0; i < targets.Length; i++) targets[i] = _world.Spawn();
 
         var entitiesPerArchetype = EntityCount / ArchetypeCount;
+        var remainder = EntityCount % ArchetypeCount;
         for (var i = 0; i < targets.Length; i++)
         {
             using var template = _world.Template()
@@ -48,12 +49,13 @@ public class CoreStreamBindingBenchmarks
                 .Add(new Component3(4))
                 .Add(new Component4(5))
                 .Add(new Fragment(), targets[i]);
-            template.Spawn(entitiesPerArchetype);
+            template.Spawn(entitiesPerArchetype + (i < remainder ? 1 : 0));
         }
 
         _stream1 = _world.Query<Component0>().Stream();
         _stream2 = _world.Query<Component0, Component1>().Stream();
         _stream5 = _world.Query<Component0, Component1, Component2, Component3, Component4>().Stream();
+        if (_stream1.Count != EntityCount) throw new InvalidOperationException("Benchmark entity count mismatch.");
     }
 
     [GlobalCleanup]

--- a/src/fennecs.benchmarks/ECS/CoreStreamBindingBenchmarks.cs
+++ b/src/fennecs.benchmarks/ECS/CoreStreamBindingBenchmarks.cs
@@ -1,0 +1,80 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Order;
+
+using fennecs;
+
+namespace Benchmark.ECS;
+
+/// <summary>
+/// Measures per-archetype stream binding and dispatch overhead without meaningful component work.
+/// </summary>
+[ShortRunJob]
+[MemoryDiagnoser]
+[Orderer(SummaryOrderPolicy.FastestToSlowest)]
+[HideColumns("Job", "Error", "RatioSD")]
+public class CoreStreamBindingBenchmarks
+{
+    private record struct Component0(int Value);
+    private record struct Component1(int Value);
+    private record struct Component2(int Value);
+    private record struct Component3(int Value);
+    private record struct Component4(int Value);
+    private record struct Fragment;
+
+    [Params(1, 64, 1024)]
+    public int ArchetypeCount { get; set; }
+
+    private const int EntityCount = 65_536;
+
+    private World _world = null!;
+    private Stream<Component0> _stream1;
+    private Stream<Component0, Component1> _stream2;
+    private Stream<Component0, Component1, Component2, Component3, Component4> _stream5;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _world = new(EntityCount + ArchetypeCount);
+        var targets = new Entity[ArchetypeCount];
+        for (var i = 0; i < targets.Length; i++) targets[i] = _world.Spawn();
+
+        var entitiesPerArchetype = EntityCount / ArchetypeCount;
+        for (var i = 0; i < targets.Length; i++)
+        {
+            using var template = _world.Template()
+                .Add(new Component0(1))
+                .Add(new Component1(2))
+                .Add(new Component2(3))
+                .Add(new Component3(4))
+                .Add(new Component4(5))
+                .Add(new Fragment(), targets[i]);
+            template.Spawn(entitiesPerArchetype);
+        }
+
+        _stream1 = _world.Query<Component0>().Stream();
+        _stream2 = _world.Query<Component0, Component1>().Stream();
+        _stream5 = _world.Query<Component0, Component1, Component2, Component3, Component4>().Stream();
+    }
+
+    [GlobalCleanup]
+    public void Cleanup() => _world.Dispose();
+
+    [Benchmark(Baseline = true)]
+    public void Raw_Arity1() => _stream1.Raw(static _ => { });
+
+    [Benchmark]
+    public void Raw_Arity2() => _stream2.Raw(static (_, _) => { });
+
+    [Benchmark]
+    public void Raw_Arity5() => _stream5.Raw(static (_, _, _, _, _) => { });
+
+    [Benchmark]
+    public void For_Arity1() => _stream1.For(static (ref Component0 _) => { });
+
+    [Benchmark]
+    public void For_Arity2() => _stream2.For(static (ref Component0 _, ref Component1 _) => { });
+
+    [Benchmark]
+    public void For_Arity5() => _stream5.For(static (ref Component0 _, ref Component1 _, ref Component2 _,
+        ref Component3 _, ref Component4 _) => { });
+}

--- a/src/fennecs.benchmarks/Program.cs
+++ b/src/fennecs.benchmarks/Program.cs
@@ -28,4 +28,7 @@ BenchmarkSwitcher.FromTypes(
     typeof(MicrocodeBenchmarks),
     typeof(SimpleEntityBenchmarks),
     typeof(EntityPassingBenchmarks),
+    typeof(CoreStreamBindingBenchmarks),
+    typeof(CoreJobSchedulingBenchmarks),
+    typeof(CoreFilteredRunnerBenchmarks),
 ]).Run(args.Length > 0 ? args : ["--filter", "*"], config);

--- a/src/fennecs.tests/CrossTests.Disposal.cs
+++ b/src/fennecs.tests/CrossTests.Disposal.cs
@@ -50,9 +50,15 @@ public class CrossDisposalTests
     // Dispose must return the matched storage lists to their pool (which clears them).
     private static void AssertDisposeClearsStorages<TJoin>(TJoin join, IEnumerable[] lists) where TJoin : IDisposable
     {
-        foreach (var list in lists) Assert.NotEmpty(list);
+        try
+        {
+            foreach (var list in lists) Assert.NotEmpty(list);
+        }
+        finally
+        {
+            join.Dispose();
+        }
 
-        join.Dispose();
         foreach (var list in lists) Assert.Empty(list);
     }
 

--- a/src/fennecs.tests/CrossTests.Disposal.cs
+++ b/src/fennecs.tests/CrossTests.Disposal.cs
@@ -27,23 +27,23 @@ public class CrossDisposalTests
         using var world = CrossTests.Setup(out var archetype);
 
         var join1 = new Cross.Join<int>(archetype,
-            [CrossTests.Plain<int>()]);
+            [CrossTests.Any<int>()]);
         AssertDisposeClearsStorages(join1, join1.TestState.Storages);
 
         var join2 = new Cross.Join<int, string>(archetype,
-            [CrossTests.Plain<int>(), CrossTests.Plain<string>()]);
+            [CrossTests.Any<int>(), CrossTests.Any<string>()]);
         AssertDisposeClearsStorages(join2, join2.TestState.Storages);
 
         var join3 = new Cross.Join<int, string, float>(archetype,
-            [CrossTests.Plain<int>(), CrossTests.Plain<string>(), CrossTests.Plain<float>()]);
+            [CrossTests.Any<int>(), CrossTests.Any<string>(), CrossTests.Any<float>()]);
         AssertDisposeClearsStorages(join3, join3.TestState.Storages);
 
         var join4 = new Cross.Join<int, string, float, double>(archetype,
-            [CrossTests.Plain<int>(), CrossTests.Plain<string>(), CrossTests.Plain<float>(), CrossTests.Plain<double>()]);
+            [CrossTests.Any<int>(), CrossTests.Any<string>(), CrossTests.Any<float>(), CrossTests.Any<double>()]);
         AssertDisposeClearsStorages(join4, join4.TestState.Storages);
 
         var join5 = new Cross.Join<int, string, float, double, byte>(archetype,
-            [CrossTests.Plain<int>(), CrossTests.Plain<string>(), CrossTests.Plain<float>(), CrossTests.Plain<double>(), CrossTests.Plain<byte>()]);
+            [CrossTests.Any<int>(), CrossTests.Any<string>(), CrossTests.Any<float>(), CrossTests.Any<double>(), CrossTests.Any<byte>()]);
         AssertDisposeClearsStorages(join5, join5.TestState.Storages);
     }
 
@@ -64,44 +64,44 @@ public class CrossDisposalTests
     {
         using var world = CrossTests.Setup(out var archetype);
 
-        var first1 = new Cross.Join<int>(archetype, [CrossTests.Plain<int>()]);
+        var first1 = new Cross.Join<int>(archetype, [CrossTests.Any<int>()]);
         var state1 = first1.TestState;
         first1.Dispose();
-        var second1 = new Cross.Join<int>(archetype, [CrossTests.Plain<int>()]);
+        var second1 = new Cross.Join<int>(archetype, [CrossTests.Any<int>()]);
         AssertArraysRecycled(state1, second1.TestState);
         second1.Dispose();
 
-        var first2 = new Cross.Join<int, string>(archetype, [CrossTests.Plain<int>(), CrossTests.Plain<string>()]);
+        var first2 = new Cross.Join<int, string>(archetype, [CrossTests.Any<int>(), CrossTests.Any<string>()]);
         var state2 = first2.TestState;
         first2.Dispose();
-        var second2 = new Cross.Join<int, string>(archetype, [CrossTests.Plain<int>(), CrossTests.Plain<string>()]);
+        var second2 = new Cross.Join<int, string>(archetype, [CrossTests.Any<int>(), CrossTests.Any<string>()]);
         AssertArraysRecycled(state2, second2.TestState);
         second2.Dispose();
 
         var first3 = new Cross.Join<int, string, float>(archetype,
-            [CrossTests.Plain<int>(), CrossTests.Plain<string>(), CrossTests.Plain<float>()]);
+            [CrossTests.Any<int>(), CrossTests.Any<string>(), CrossTests.Any<float>()]);
         var state3 = first3.TestState;
         first3.Dispose();
         var second3 = new Cross.Join<int, string, float>(archetype,
-            [CrossTests.Plain<int>(), CrossTests.Plain<string>(), CrossTests.Plain<float>()]);
+            [CrossTests.Any<int>(), CrossTests.Any<string>(), CrossTests.Any<float>()]);
         AssertArraysRecycled(state3, second3.TestState);
         second3.Dispose();
 
         var first4 = new Cross.Join<int, string, float, double>(archetype,
-            [CrossTests.Plain<int>(), CrossTests.Plain<string>(), CrossTests.Plain<float>(), CrossTests.Plain<double>()]);
+            [CrossTests.Any<int>(), CrossTests.Any<string>(), CrossTests.Any<float>(), CrossTests.Any<double>()]);
         var state4 = first4.TestState;
         first4.Dispose();
         var second4 = new Cross.Join<int, string, float, double>(archetype,
-            [CrossTests.Plain<int>(), CrossTests.Plain<string>(), CrossTests.Plain<float>(), CrossTests.Plain<double>()]);
+            [CrossTests.Any<int>(), CrossTests.Any<string>(), CrossTests.Any<float>(), CrossTests.Any<double>()]);
         AssertArraysRecycled(state4, second4.TestState);
         second4.Dispose();
 
         var first5 = new Cross.Join<int, string, float, double, byte>(archetype,
-            [CrossTests.Plain<int>(), CrossTests.Plain<string>(), CrossTests.Plain<float>(), CrossTests.Plain<double>(), CrossTests.Plain<byte>()]);
+            [CrossTests.Any<int>(), CrossTests.Any<string>(), CrossTests.Any<float>(), CrossTests.Any<double>(), CrossTests.Any<byte>()]);
         var state5 = first5.TestState;
         first5.Dispose();
         var second5 = new Cross.Join<int, string, float, double, byte>(archetype,
-            [CrossTests.Plain<int>(), CrossTests.Plain<string>(), CrossTests.Plain<float>(), CrossTests.Plain<double>(), CrossTests.Plain<byte>()]);
+            [CrossTests.Any<int>(), CrossTests.Any<string>(), CrossTests.Any<float>(), CrossTests.Any<double>(), CrossTests.Any<byte>()]);
         AssertArraysRecycled(state5, second5.TestState);
         second5.Dispose();
     }

--- a/src/fennecs.tests/CrossTests.Disposal.cs
+++ b/src/fennecs.tests/CrossTests.Disposal.cs
@@ -11,6 +11,42 @@ public class SharedPoolTests;
 [Collection(nameof(SharedPoolTests))]
 public class CrossDisposalTests
 {
+    private static void AssertDirectDispose<TJoin>(TJoin join,
+        (int[] Counter, int[] Limiter, IEnumerable[] Storages) state) where TJoin : IDisposable
+    {
+        Assert.Null(state.Counter);
+        Assert.Null(state.Limiter);
+        Assert.All(state.Storages, storage => Assert.Null(storage));
+        join.Dispose();
+    }
+
+
+    [Fact]
+    public void Direct_Join_Dispose_Has_No_Pooled_State()
+    {
+        using var world = CrossTests.Setup(out var archetype);
+
+        var join1 = new Cross.Join<int>(archetype, [CrossTests.Plain<int>()]);
+        AssertDirectDispose(join1, join1.TestState);
+
+        var join2 = new Cross.Join<int, string>(archetype, [CrossTests.Plain<int>(), CrossTests.Plain<string>()]);
+        AssertDirectDispose(join2, join2.TestState);
+
+        var join3 = new Cross.Join<int, string, float>(archetype,
+            [CrossTests.Plain<int>(), CrossTests.Plain<string>(), CrossTests.Plain<float>()]);
+        AssertDirectDispose(join3, join3.TestState);
+
+        var join4 = new Cross.Join<int, string, float, double>(archetype,
+            [CrossTests.Plain<int>(), CrossTests.Plain<string>(), CrossTests.Plain<float>(), CrossTests.Plain<double>()]);
+        AssertDirectDispose(join4, join4.TestState);
+
+        var join5 = new Cross.Join<int, string, float, double, byte>(archetype,
+            [CrossTests.Plain<int>(), CrossTests.Plain<string>(), CrossTests.Plain<float>(), CrossTests.Plain<double>(),
+                CrossTests.Plain<byte>()]);
+        AssertDirectDispose(join5, join5.TestState);
+    }
+
+
     // Dispose must return the matched storage lists to their pool (which clears them).
     private static void AssertDisposeClearsStorages<TJoin>(TJoin join, IEnumerable[] lists) where TJoin : IDisposable
     {

--- a/src/fennecs.tests/CrossTests.cs
+++ b/src/fennecs.tests/CrossTests.cs
@@ -37,6 +37,7 @@ public class CrossTests
     }
 
     internal static TypeExpression Plain<T>() => TypeExpression.Of<T>(Match.Plain);
+    internal static TypeExpression Any<T>() => TypeExpression.Of<T>(Match.Any);
 
 
     [Fact]

--- a/src/fennecs.tests/Stream/JobExceptionTests.cs
+++ b/src/fennecs.tests/Stream/JobExceptionTests.cs
@@ -4,6 +4,8 @@ namespace fennecs.tests.Stream;
 // nor crash the process (unhandled thread pool exception) — it surfaces as AggregateException.
 public class JobExceptionTests
 {
+    private struct Fragment;
+
     private static World Setup(out fennecs.Stream<int> stream)
     {
         var world = new World();
@@ -57,6 +59,27 @@ public class JobExceptionTests
         AssertJobFaults(() => stream.Job((ref int _, ref float _) => throw new InvalidOperationException("boom")));
 
         world.Spawn().Add(1);
+    }
+
+
+    [Fact]
+    public void Segmented_Job_Continues_Other_Segments_After_Exception()
+    {
+        var count = Math.Max(128, Environment.ProcessorCount * 4);
+        using var world = new World();
+        var targets = new Entity[count];
+        for (var i = 0; i < count; i++) targets[i] = world.Spawn();
+        for (var i = 0; i < count; i++) world.Spawn().Add(i).Add<Fragment>(targets[i]);
+
+        var stream = world.Query<int>().Stream();
+        var visited = 0;
+        AssertJobFaults(() => stream.Job((ref int value) =>
+        {
+            if (value < 2) throw new InvalidOperationException("boom");
+            Interlocked.Increment(ref visited);
+        }));
+
+        Assert.Equal(count - 2, visited);
     }
 
 

--- a/src/fennecs/Cross.cs
+++ b/src/fennecs/Cross.cs
@@ -48,8 +48,10 @@ public static class Cross
         private readonly int[] _limiter;
 
         private readonly PooledList<Storage<C0>> _storages0;
+        private readonly Storage<C0> _direct0;
 
         private readonly bool _allocated;
+        private readonly bool _direct;
         private readonly bool _populated;
 
 
@@ -59,7 +61,22 @@ public static class Cross
         internal Join(Archetype archetype, ReadOnlySpan<TypeExpression> streamTypes)
         {
             Debug.Assert(streamTypes.Length == 1, "Not the right amount of stream types.");
+
+            if (!streamTypes[0].isWildcard)
+            {
+                _counter = null!;
+                _limiter = null!;
+                _storages0 = null!;
+                _allocated = false;
+                _direct = true;
+                _populated = archetype.TryGetStorage(streamTypes[0], out var storage0);
+                _direct0 = _populated ? (Storage<C0>)storage0 : null!;
+                return;
+            }
+
             _allocated = true;
+            _direct = false;
+            _direct0 = null!;
 
             _counter = ArrayPool.Rent(1);
             _limiter = ArrayPool.Rent(1);
@@ -75,7 +92,7 @@ public static class Cross
         /// Returns the Storage in the current internal Cross Join counter configuration.
         /// Call <see cref="Iterate"/> to select the next permutation.
         /// </summary>
-        internal Storage<C0> Select => _storages0[_counter[0]];
+        internal Storage<C0> Select => _direct ? _direct0 : _storages0[_counter[0]];
 
         // Test seam: bookkeeping internals for disposal / pool round-trip verification.
         internal (int[] Counter, int[] Limiter, IEnumerable[] Storages) TestState =>
@@ -90,6 +107,7 @@ public static class Cross
         /// </returns>
         internal bool Iterate()
         {
+            if (_direct) return false;
             Debug.Assert(_counter is { Length: >= 1 });
             Debug.Assert(_limiter is { Length: >= 1 });
             return FullPermutation(_counter.AsSpan(0, 1), _limiter.AsSpan(0, 1));
@@ -104,7 +122,7 @@ public static class Cross
 
         public void Dispose()
         {
-            if (!_allocated) return;
+            if (_direct || !_allocated) return;
 
             _storages0.Dispose();
             ArrayPool.Return(_counter);
@@ -123,14 +141,37 @@ public static class Cross
 
         private readonly PooledList<Storage<C0>> _storages0;
         private readonly PooledList<Storage<C1>> _storages1;
+        private readonly Storage<C0> _direct0;
+        private readonly Storage<C1> _direct1;
 
         private readonly bool _allocated;
+        private readonly bool _direct;
         private readonly bool _populated;
         
         internal Join(Archetype archetype, ReadOnlySpan<TypeExpression> streamTypes)
         {
             Debug.Assert(streamTypes.Length == 2, "Not the right amount of stream types.");
+
+            if (!streamTypes[0].isWildcard && !streamTypes[1].isWildcard)
+            {
+                _counter = null!;
+                _limiter = null!;
+                _storages0 = null!;
+                _storages1 = null!;
+                _allocated = false;
+                _direct = true;
+                var has0 = archetype.TryGetStorage(streamTypes[0], out var storage0);
+                var has1 = archetype.TryGetStorage(streamTypes[1], out var storage1);
+                _populated = has0 && has1;
+                _direct0 = has0 ? (Storage<C0>)storage0 : null!;
+                _direct1 = has1 ? (Storage<C1>)storage1 : null!;
+                return;
+            }
+
             _allocated = true;
+            _direct = false;
+            _direct0 = null!;
+            _direct1 = null!;
 
             _counter = ArrayPool.Rent(2);
             _limiter = ArrayPool.Rent(2);
@@ -145,7 +186,9 @@ public static class Cross
         }
 
 
-        internal (Storage<C0>, Storage<C1>) Select => (_storages0[_counter[0]], _storages1[_counter[1]]);
+        internal (Storage<C0>, Storage<C1>) Select => _direct
+            ? (_direct0, _direct1)
+            : (_storages0[_counter[0]], _storages1[_counter[1]]);
 
         // Test seam: bookkeeping internals for disposal / pool round-trip verification.
         internal (int[] Counter, int[] Limiter, IEnumerable[] Storages) TestState =>
@@ -153,6 +196,7 @@ public static class Cross
 
         internal bool Iterate()
         {
+            if (_direct) return false;
             Debug.Assert(_counter is { Length: >= 2 });
             Debug.Assert(_limiter is { Length: >= 2 });
             return FullPermutation(_counter.AsSpan(0, 2), _limiter.AsSpan(0, 2));
@@ -163,7 +207,7 @@ public static class Cross
 
         public void Dispose()
         {
-            if (!_allocated) return;
+            if (_direct || !_allocated) return;
 
             _storages0.Dispose();
             _storages1.Dispose();
@@ -184,15 +228,43 @@ public static class Cross
         private readonly PooledList<Storage<C0>> _storages0;
         private readonly PooledList<Storage<C1>> _storages1;
         private readonly PooledList<Storage<C2>> _storages2;
+        private readonly Storage<C0> _direct0;
+        private readonly Storage<C1> _direct1;
+        private readonly Storage<C2> _direct2;
 
         private readonly bool _allocated;
+        private readonly bool _direct;
         private readonly bool _populated;
 
 
         internal Join(Archetype archetype, ReadOnlySpan<TypeExpression> streamTypes)
         {
             Debug.Assert(streamTypes.Length == 3, "Not the right amount of stream types.");
+
+            if (!streamTypes[0].isWildcard && !streamTypes[1].isWildcard && !streamTypes[2].isWildcard)
+            {
+                _counter = null!;
+                _limiter = null!;
+                _storages0 = null!;
+                _storages1 = null!;
+                _storages2 = null!;
+                _allocated = false;
+                _direct = true;
+                var has0 = archetype.TryGetStorage(streamTypes[0], out var storage0);
+                var has1 = archetype.TryGetStorage(streamTypes[1], out var storage1);
+                var has2 = archetype.TryGetStorage(streamTypes[2], out var storage2);
+                _populated = has0 && has1 && has2;
+                _direct0 = has0 ? (Storage<C0>)storage0 : null!;
+                _direct1 = has1 ? (Storage<C1>)storage1 : null!;
+                _direct2 = has2 ? (Storage<C2>)storage2 : null!;
+                return;
+            }
+
             _allocated = true;
+            _direct = false;
+            _direct0 = null!;
+            _direct1 = null!;
+            _direct2 = null!;
 
             _counter = ArrayPool.Rent(3);
             _limiter = ArrayPool.Rent(3);
@@ -209,8 +281,9 @@ public static class Cross
         }
 
 
-        internal (Storage<C0>, Storage<C1>, Storage<C2>) Select =>
-            (_storages0[_counter[0]], _storages1[_counter[1]], _storages2[_counter[2]]);
+        internal (Storage<C0>, Storage<C1>, Storage<C2>) Select => _direct
+            ? (_direct0, _direct1, _direct2)
+            : (_storages0[_counter[0]], _storages1[_counter[1]], _storages2[_counter[2]]);
 
         // Test seam: bookkeeping internals for disposal / pool round-trip verification.
         internal (int[] Counter, int[] Limiter, IEnumerable[] Storages) TestState =>
@@ -218,6 +291,7 @@ public static class Cross
 
         internal bool Iterate()
         {
+            if (_direct) return false;
             Debug.Assert(_counter is { Length: >= 3 });
             Debug.Assert(_limiter is { Length: >= 3 });
             return FullPermutation(_counter.AsSpan(0, 3), _limiter.AsSpan(0, 3));
@@ -228,7 +302,7 @@ public static class Cross
 
         public void Dispose()
         {
-            if (!_allocated) return;
+            if (_direct || !_allocated) return;
 
             _storages0.Dispose();
             _storages1.Dispose();
@@ -251,15 +325,49 @@ public static class Cross
         private readonly PooledList<Storage<C1>> _storages1;
         private readonly PooledList<Storage<C2>> _storages2;
         private readonly PooledList<Storage<C3>> _storages3;
+        private readonly Storage<C0> _direct0;
+        private readonly Storage<C1> _direct1;
+        private readonly Storage<C2> _direct2;
+        private readonly Storage<C3> _direct3;
 
         private readonly bool _allocated;
+        private readonly bool _direct;
         private readonly bool _populated;
 
 
         internal Join(Archetype archetype, ReadOnlySpan<TypeExpression> streamTypes)
         {
             Debug.Assert(streamTypes.Length == 4, "Not the right amount of stream types.");
+
+            if (!streamTypes[0].isWildcard && !streamTypes[1].isWildcard && !streamTypes[2].isWildcard &&
+                !streamTypes[3].isWildcard)
+            {
+                _counter = null!;
+                _limiter = null!;
+                _storages0 = null!;
+                _storages1 = null!;
+                _storages2 = null!;
+                _storages3 = null!;
+                _allocated = false;
+                _direct = true;
+                var has0 = archetype.TryGetStorage(streamTypes[0], out var storage0);
+                var has1 = archetype.TryGetStorage(streamTypes[1], out var storage1);
+                var has2 = archetype.TryGetStorage(streamTypes[2], out var storage2);
+                var has3 = archetype.TryGetStorage(streamTypes[3], out var storage3);
+                _populated = has0 && has1 && has2 && has3;
+                _direct0 = has0 ? (Storage<C0>)storage0 : null!;
+                _direct1 = has1 ? (Storage<C1>)storage1 : null!;
+                _direct2 = has2 ? (Storage<C2>)storage2 : null!;
+                _direct3 = has3 ? (Storage<C3>)storage3 : null!;
+                return;
+            }
+
             _allocated = true;
+            _direct = false;
+            _direct0 = null!;
+            _direct1 = null!;
+            _direct2 = null!;
+            _direct3 = null!;
 
             _counter = ArrayPool.Rent(4);
             _limiter = ArrayPool.Rent(4);
@@ -278,8 +386,9 @@ public static class Cross
         }
 
 
-        internal (Storage<C0>, Storage<C1>, Storage<C2>, Storage<C3>) Select => (_storages0[_counter[0]],
-            _storages1[_counter[1]], _storages2[_counter[2]], _storages3[_counter[3]]);
+        internal (Storage<C0>, Storage<C1>, Storage<C2>, Storage<C3>) Select => _direct
+            ? (_direct0, _direct1, _direct2, _direct3)
+            : (_storages0[_counter[0]], _storages1[_counter[1]], _storages2[_counter[2]], _storages3[_counter[3]]);
 
         // Test seam: bookkeeping internals for disposal / pool round-trip verification.
         internal (int[] Counter, int[] Limiter, IEnumerable[] Storages) TestState =>
@@ -287,6 +396,7 @@ public static class Cross
 
         internal bool Iterate()
         {
+            if (_direct) return false;
             Debug.Assert(_counter is { Length: >= 4 });
             Debug.Assert(_limiter is { Length: >= 4 });
             return FullPermutation(_counter.AsSpan(0, 4), _limiter.AsSpan(0, 4));
@@ -297,7 +407,7 @@ public static class Cross
 
         public void Dispose()
         {
-            if (!_allocated) return;
+            if (_direct || !_allocated) return;
 
             _storages0.Dispose();
             _storages1.Dispose();
@@ -322,15 +432,54 @@ public static class Cross
         private readonly PooledList<Storage<C2>> _storages2;
         private readonly PooledList<Storage<C3>> _storages3;
         private readonly PooledList<Storage<C4>> _storages4;
+        private readonly Storage<C0> _direct0;
+        private readonly Storage<C1> _direct1;
+        private readonly Storage<C2> _direct2;
+        private readonly Storage<C3> _direct3;
+        private readonly Storage<C4> _direct4;
 
         private readonly bool _allocated;
+        private readonly bool _direct;
         private readonly bool _populated;
 
 
         internal Join(Archetype archetype, ReadOnlySpan<TypeExpression> streamTypes)
         {
             Debug.Assert(streamTypes.Length == 5, "Not the right amount of stream types.");
+
+            if (!streamTypes[0].isWildcard && !streamTypes[1].isWildcard && !streamTypes[2].isWildcard &&
+                !streamTypes[3].isWildcard && !streamTypes[4].isWildcard)
+            {
+                _counter = null!;
+                _limiter = null!;
+                _storages0 = null!;
+                _storages1 = null!;
+                _storages2 = null!;
+                _storages3 = null!;
+                _storages4 = null!;
+                _allocated = false;
+                _direct = true;
+                var has0 = archetype.TryGetStorage(streamTypes[0], out var storage0);
+                var has1 = archetype.TryGetStorage(streamTypes[1], out var storage1);
+                var has2 = archetype.TryGetStorage(streamTypes[2], out var storage2);
+                var has3 = archetype.TryGetStorage(streamTypes[3], out var storage3);
+                var has4 = archetype.TryGetStorage(streamTypes[4], out var storage4);
+                _populated = has0 && has1 && has2 && has3 && has4;
+                _direct0 = has0 ? (Storage<C0>)storage0 : null!;
+                _direct1 = has1 ? (Storage<C1>)storage1 : null!;
+                _direct2 = has2 ? (Storage<C2>)storage2 : null!;
+                _direct3 = has3 ? (Storage<C3>)storage3 : null!;
+                _direct4 = has4 ? (Storage<C4>)storage4 : null!;
+                return;
+            }
+
             _allocated = true;
+            _direct = false;
+            _direct0 = null!;
+            _direct1 = null!;
+            _direct2 = null!;
+            _direct3 = null!;
+            _direct4 = null!;
 
             _counter = ArrayPool.Rent(5);
             _limiter = ArrayPool.Rent(5);
@@ -352,8 +501,10 @@ public static class Cross
         }
 
 
-        internal (Storage<C0>, Storage<C1>, Storage<C2>, Storage<C3>, Storage<C4>) Select => (_storages0[_counter[0]],
-            _storages1[_counter[1]], _storages2[_counter[2]], _storages3[_counter[3]], _storages4[_counter[4]]);
+        internal (Storage<C0>, Storage<C1>, Storage<C2>, Storage<C3>, Storage<C4>) Select => _direct
+            ? (_direct0, _direct1, _direct2, _direct3, _direct4)
+            : (_storages0[_counter[0]], _storages1[_counter[1]], _storages2[_counter[2]], _storages3[_counter[3]],
+                _storages4[_counter[4]]);
 
         // Test seam: bookkeeping internals for disposal / pool round-trip verification.
         internal (int[] Counter, int[] Limiter, IEnumerable[] Storages) TestState =>
@@ -361,6 +512,7 @@ public static class Cross
 
         internal bool Iterate()
         {
+            if (_direct) return false;
             Debug.Assert(_counter is { Length: >= 5 });
             Debug.Assert(_limiter is { Length: >= 5 });
             return FullPermutation(_counter.AsSpan(0, 5), _limiter.AsSpan(0, 5));
@@ -371,7 +523,7 @@ public static class Cross
 
         public void Dispose()
         {
-            if (!_allocated) return;
+            if (_direct || !_allocated) return;
 
             _storages0.Dispose();
             _storages1.Dispose();

--- a/src/fennecs/Workloads.cs
+++ b/src/fennecs/Workloads.cs
@@ -1,3 +1,5 @@
+using System.Runtime.ExceptionServices;
+
 namespace fennecs;
 
 /// <summary>
@@ -26,6 +28,13 @@ internal abstract class Workload : IThreadPoolWorkItem
     }
 
     protected abstract void Run();
+
+    protected static void RethrowSegmentFaults(List<Exception>? faults)
+    {
+        if (faults is null) return;
+        if (faults.Count == 1) ExceptionDispatchInfo.Capture(faults[0]).Throw();
+        throw new AggregateException(faults);
+    }
 }
 
 internal static class Workloads
@@ -38,7 +47,14 @@ internal static class Workloads
         foreach (var job in jobs)
         {
             if (job.Exception is null) continue;
-            (faults ??= []).Add(job.Exception);
+            if (job.Exception is AggregateException aggregate)
+            {
+                (faults ??= []).AddRange(aggregate.Flatten().InnerExceptions);
+            }
+            else
+            {
+                (faults ??= []).Add(job.Exception);
+            }
             job.Exception = null;
         }
     }
@@ -55,10 +71,29 @@ internal static class Workloads
 internal class Work<C1> : Workload
 {
     public Memory<C1> Memory1 = null!;
+    public pools.PooledList<Memory<C1>>? Segments;
     public ComponentAction<C1> Action = null!;
 
     protected override void Run()
     {
+        if (Segments is { } segments)
+        {
+            List<Exception>? faults = null;
+            foreach (var memory in segments)
+            {
+                try
+                {
+                    foreach (ref var component in memory.Span) Action(ref component);
+                }
+                catch (Exception exception)
+                {
+                    (faults ??= []).Add(exception);
+                }
+            }
+            RethrowSegmentFaults(faults);
+            return;
+        }
+
         foreach (ref var c in Memory1.Span)
         {
             Action(ref c);
@@ -69,11 +104,30 @@ internal class Work<C1> : Workload
 internal class UniformWork<U, C1> : Workload
 {
     public Memory<C1> Memory1 = null!;
+    public pools.PooledList<Memory<C1>>? Segments;
     public UniformComponentAction<U, C1> Action = null!;
     public U Uniform = default!;
 
     protected override void Run()
     {
+        if (Segments is { } segments)
+        {
+            List<Exception>? faults = null;
+            foreach (var memory in segments)
+            {
+                try
+                {
+                    foreach (ref var component in memory.Span) Action(Uniform, ref component);
+                }
+                catch (Exception exception)
+                {
+                    (faults ??= []).Add(exception);
+                }
+            }
+            RethrowSegmentFaults(faults);
+            return;
+        }
+
         foreach (ref var c in Memory1.Span)
         {
             Action(Uniform, ref c);
@@ -86,14 +140,24 @@ internal class DualWork<C1> : Workload
     public Memory<C1> Memory1 = null!;
     public FilterDelegate<C1> Pass = null!;
     public ComponentAction<C1> Included = null!;
-    public ComponentAction<C1> Excluded = null!;
+    public ComponentAction<C1>? Excluded;
 
     protected override void Run()
     {
+        var excluded = Excluded;
+        if (excluded is null)
+        {
+            foreach (ref var c in Memory1.Span)
+            {
+                if (Pass(in c)) Included(ref c);
+            }
+            return;
+        }
+
         foreach (ref var c in Memory1.Span)
         {
             if (Pass(in c)) Included(ref c);
-            else Excluded(ref c);
+            else excluded(ref c);
         }
     }
 }
@@ -103,15 +167,25 @@ internal class UniformDualWork<U, C1> : Workload
     public Memory<C1> Memory1 = null!;
     public FilterDelegate<C1> Pass = null!;
     public UniformComponentAction<U, C1> Included = null!;
-    public UniformComponentAction<U, C1> Excluded = null!;
+    public UniformComponentAction<U, C1>? Excluded;
     public U Uniform = default!;
 
     protected override void Run()
     {
+        var excluded = Excluded;
+        if (excluded is null)
+        {
+            foreach (ref var c in Memory1.Span)
+            {
+                if (Pass(in c)) Included(Uniform, ref c);
+            }
+            return;
+        }
+
         foreach (ref var c in Memory1.Span)
         {
             if (Pass(in c)) Included(Uniform, ref c);
-            else Excluded(Uniform, ref c);
+            else excluded(Uniform, ref c);
         }
     }
 }
@@ -120,10 +194,31 @@ internal class Work<C1, C2> : Workload
 {
     public Memory<C1> Memory1 = null!;
     public Memory<C2> Memory2 = null!;
+    public pools.PooledList<(Memory<C1>, Memory<C2>)>? Segments;
     public ComponentAction<C1, C2> Action = null!;
 
     protected override void Run()
     {
+        if (Segments is { } segments)
+        {
+            List<Exception>? faults = null;
+            foreach (var (memory1, memory2) in segments)
+            {
+                try
+                {
+                    var segment1 = memory1.Span;
+                    var segment2 = memory2.Span;
+                    for (var i = 0; i < segment1.Length; i++) Action(ref segment1[i], ref segment2[i]);
+                }
+                catch (Exception exception)
+                {
+                    (faults ??= []).Add(exception);
+                }
+            }
+            RethrowSegmentFaults(faults);
+            return;
+        }
+
         var s1 = Memory1.Span;
         var s2 = Memory2.Span;
         for (var i = 0; i < Memory1.Length; i++)
@@ -137,6 +232,7 @@ internal class UniformWork<U, C1, C2> : Workload
 {
     public Memory<C1> Memory1 = null!;
     public Memory<C2> Memory2 = null!;
+    public pools.PooledList<(Memory<C1>, Memory<C2>)>? Segments;
 
     public UniformComponentAction<U, C1, C2> Action = null!;
     public U Uniform = default!;
@@ -144,6 +240,26 @@ internal class UniformWork<U, C1, C2> : Workload
 
     protected override void Run()
     {
+        if (Segments is { } segments)
+        {
+            List<Exception>? faults = null;
+            foreach (var (memory1, memory2) in segments)
+            {
+                try
+                {
+                    var segment1 = memory1.Span;
+                    var segment2 = memory2.Span;
+                    for (var i = 0; i < segment1.Length; i++) Action(Uniform, ref segment1[i], ref segment2[i]);
+                }
+                catch (Exception exception)
+                {
+                    (faults ??= []).Add(exception);
+                }
+            }
+            RethrowSegmentFaults(faults);
+            return;
+        }
+
         var s1 = Memory1.Span;
         var s2 = Memory2.Span;
 
@@ -160,16 +276,26 @@ internal class DualWork<C1, C2> : Workload
     public Memory<C2> Memory2 = null!;
     public FilterDelegate<C1, C2> Pass = null!;
     public ComponentAction<C1, C2> Included = null!;
-    public ComponentAction<C1, C2> Excluded = null!;
+    public ComponentAction<C1, C2>? Excluded;
 
     protected override void Run()
     {
         var s1 = Memory1.Span;
         var s2 = Memory2.Span;
+        var excluded = Excluded;
+        if (excluded is null)
+        {
+            for (var i = 0; i < Memory1.Length; i++)
+            {
+                if (Pass(in s1[i], in s2[i])) Included(ref s1[i], ref s2[i]);
+            }
+            return;
+        }
+
         for (var i = 0; i < Memory1.Length; i++)
         {
             if (Pass(in s1[i], in s2[i])) Included(ref s1[i], ref s2[i]);
-            else Excluded(ref s1[i], ref s2[i]);
+            else excluded(ref s1[i], ref s2[i]);
         }
     }
 }
@@ -180,17 +306,27 @@ internal class UniformDualWork<U, C1, C2> : Workload
     public Memory<C2> Memory2 = null!;
     public FilterDelegate<C1, C2> Pass = null!;
     public UniformComponentAction<U, C1, C2> Included = null!;
-    public UniformComponentAction<U, C1, C2> Excluded = null!;
+    public UniformComponentAction<U, C1, C2>? Excluded;
     public U Uniform = default!;
 
     protected override void Run()
     {
         var s1 = Memory1.Span;
         var s2 = Memory2.Span;
+        var excluded = Excluded;
+        if (excluded is null)
+        {
+            for (var i = 0; i < Memory1.Length; i++)
+            {
+                if (Pass(in s1[i], in s2[i])) Included(Uniform, ref s1[i], ref s2[i]);
+            }
+            return;
+        }
+
         for (var i = 0; i < Memory1.Length; i++)
         {
             if (Pass(in s1[i], in s2[i])) Included(Uniform, ref s1[i], ref s2[i]);
-            else Excluded(Uniform, ref s1[i], ref s2[i]);
+            else excluded(Uniform, ref s1[i], ref s2[i]);
         }
     }
 }
@@ -200,12 +336,35 @@ internal class Work<C1, C2, C3> : Workload
     public Memory<C1> Memory1 = null!;
     public Memory<C2> Memory2 = null!;
     public Memory<C3> Memory3 = null!;
+    public pools.PooledList<(Memory<C1>, Memory<C2>, Memory<C3>)>? Segments;
 
     public ComponentAction<C1, C2, C3> Action = null!;
 
 
     protected override void Run()
     {
+        if (Segments is { } segments)
+        {
+            List<Exception>? faults = null;
+            foreach (var (memory1, memory2, memory3) in segments)
+            {
+                try
+                {
+                    var segment1 = memory1.Span;
+                    var segment2 = memory2.Span;
+                    var segment3 = memory3.Span;
+                    for (var i = 0; i < segment1.Length; i++)
+                        Action(ref segment1[i], ref segment2[i], ref segment3[i]);
+                }
+                catch (Exception exception)
+                {
+                    (faults ??= []).Add(exception);
+                }
+            }
+            RethrowSegmentFaults(faults);
+            return;
+        }
+
         var s1 = Memory1.Span;
         var s2 = Memory2.Span;
         var s3 = Memory3.Span;
@@ -222,6 +381,7 @@ internal class UniformWork<U, C1, C2, C3> : Workload
     public Memory<C1> Memory1 = null!;
     public Memory<C2> Memory2 = null!;
     public Memory<C3> Memory3 = null!;
+    public pools.PooledList<(Memory<C1>, Memory<C2>, Memory<C3>)>? Segments;
 
     public UniformComponentAction<U, C1, C2, C3> Action = null!;
     public U Uniform = default!;
@@ -229,6 +389,28 @@ internal class UniformWork<U, C1, C2, C3> : Workload
 
     protected override void Run()
     {
+        if (Segments is { } segments)
+        {
+            List<Exception>? faults = null;
+            foreach (var (memory1, memory2, memory3) in segments)
+            {
+                try
+                {
+                    var segment1 = memory1.Span;
+                    var segment2 = memory2.Span;
+                    var segment3 = memory3.Span;
+                    for (var i = 0; i < segment1.Length; i++)
+                        Action(Uniform, ref segment1[i], ref segment2[i], ref segment3[i]);
+                }
+                catch (Exception exception)
+                {
+                    (faults ??= []).Add(exception);
+                }
+            }
+            RethrowSegmentFaults(faults);
+            return;
+        }
+
         var s1 = Memory1.Span;
         var s2 = Memory2.Span;
         var s3 = Memory3.Span;
@@ -247,17 +429,27 @@ internal class DualWork<C1, C2, C3> : Workload
     public Memory<C3> Memory3 = null!;
     public FilterDelegate<C1, C2, C3> Pass = null!;
     public ComponentAction<C1, C2, C3> Included = null!;
-    public ComponentAction<C1, C2, C3> Excluded = null!;
+    public ComponentAction<C1, C2, C3>? Excluded;
 
     protected override void Run()
     {
         var s1 = Memory1.Span;
         var s2 = Memory2.Span;
         var s3 = Memory3.Span;
+        var excluded = Excluded;
+        if (excluded is null)
+        {
+            for (var i = 0; i < Memory1.Length; i++)
+            {
+                if (Pass(in s1[i], in s2[i], in s3[i])) Included(ref s1[i], ref s2[i], ref s3[i]);
+            }
+            return;
+        }
+
         for (var i = 0; i < Memory1.Length; i++)
         {
             if (Pass(in s1[i], in s2[i], in s3[i])) Included(ref s1[i], ref s2[i], ref s3[i]);
-            else Excluded(ref s1[i], ref s2[i], ref s3[i]);
+            else excluded(ref s1[i], ref s2[i], ref s3[i]);
         }
     }
 }
@@ -269,7 +461,7 @@ internal class UniformDualWork<U, C1, C2, C3> : Workload
     public Memory<C3> Memory3 = null!;
     public FilterDelegate<C1, C2, C3> Pass = null!;
     public UniformComponentAction<U, C1, C2, C3> Included = null!;
-    public UniformComponentAction<U, C1, C2, C3> Excluded = null!;
+    public UniformComponentAction<U, C1, C2, C3>? Excluded;
     public U Uniform = default!;
 
     protected override void Run()
@@ -277,10 +469,20 @@ internal class UniformDualWork<U, C1, C2, C3> : Workload
         var s1 = Memory1.Span;
         var s2 = Memory2.Span;
         var s3 = Memory3.Span;
+        var excluded = Excluded;
+        if (excluded is null)
+        {
+            for (var i = 0; i < Memory1.Length; i++)
+            {
+                if (Pass(in s1[i], in s2[i], in s3[i])) Included(Uniform, ref s1[i], ref s2[i], ref s3[i]);
+            }
+            return;
+        }
+
         for (var i = 0; i < Memory1.Length; i++)
         {
             if (Pass(in s1[i], in s2[i], in s3[i])) Included(Uniform, ref s1[i], ref s2[i], ref s3[i]);
-            else Excluded(Uniform, ref s1[i], ref s2[i], ref s3[i]);
+            else excluded(Uniform, ref s1[i], ref s2[i], ref s3[i]);
         }
     }
 }
@@ -291,12 +493,36 @@ internal class Work<C1, C2, C3, C4> : Workload
     public Memory<C2> Memory2 = null!;
     public Memory<C3> Memory3 = null!;
     public Memory<C4> Memory4 = null!;
+    public pools.PooledList<(Memory<C1>, Memory<C2>, Memory<C3>, Memory<C4>)>? Segments;
 
     public ComponentAction<C1, C2, C3, C4> Action = null!;
 
 
     protected override void Run()
     {
+        if (Segments is { } segments)
+        {
+            List<Exception>? faults = null;
+            foreach (var (memory1, memory2, memory3, memory4) in segments)
+            {
+                try
+                {
+                    var segment1 = memory1.Span;
+                    var segment2 = memory2.Span;
+                    var segment3 = memory3.Span;
+                    var segment4 = memory4.Span;
+                    for (var i = 0; i < segment1.Length; i++)
+                        Action(ref segment1[i], ref segment2[i], ref segment3[i], ref segment4[i]);
+                }
+                catch (Exception exception)
+                {
+                    (faults ??= []).Add(exception);
+                }
+            }
+            RethrowSegmentFaults(faults);
+            return;
+        }
+
         var s1 = Memory1.Span;
         var s2 = Memory2.Span;
         var s3 = Memory3.Span;
@@ -315,6 +541,7 @@ internal class UniformWork<U, C1, C2, C3, C4> : Workload
     public Memory<C2> Memory2 = null!;
     public Memory<C3> Memory3 = null!;
     public Memory<C4> Memory4 = null!;
+    public pools.PooledList<(Memory<C1>, Memory<C2>, Memory<C3>, Memory<C4>)>? Segments;
 
     public UniformComponentAction<U, C1, C2, C3, C4> Action = null!;
     public U Uniform = default!;
@@ -322,6 +549,29 @@ internal class UniformWork<U, C1, C2, C3, C4> : Workload
 
     protected override void Run()
     {
+        if (Segments is { } segments)
+        {
+            List<Exception>? faults = null;
+            foreach (var (memory1, memory2, memory3, memory4) in segments)
+            {
+                try
+                {
+                    var segment1 = memory1.Span;
+                    var segment2 = memory2.Span;
+                    var segment3 = memory3.Span;
+                    var segment4 = memory4.Span;
+                    for (var i = 0; i < segment1.Length; i++)
+                        Action(Uniform, ref segment1[i], ref segment2[i], ref segment3[i], ref segment4[i]);
+                }
+                catch (Exception exception)
+                {
+                    (faults ??= []).Add(exception);
+                }
+            }
+            RethrowSegmentFaults(faults);
+            return;
+        }
+
         var s1 = Memory1.Span;
         var s2 = Memory2.Span;
         var s3 = Memory3.Span;
@@ -341,7 +591,7 @@ internal class DualWork<C1, C2, C3, C4> : Workload
     public Memory<C4> Memory4 = null!;
     public FilterDelegate<C1, C2, C3, C4> Pass = null!;
     public ComponentAction<C1, C2, C3, C4> Included = null!;
-    public ComponentAction<C1, C2, C3, C4> Excluded = null!;
+    public ComponentAction<C1, C2, C3, C4>? Excluded;
 
     protected override void Run()
     {
@@ -349,10 +599,20 @@ internal class DualWork<C1, C2, C3, C4> : Workload
         var s2 = Memory2.Span;
         var s3 = Memory3.Span;
         var s4 = Memory4.Span;
+        var excluded = Excluded;
+        if (excluded is null)
+        {
+            for (var i = 0; i < Memory1.Length; i++)
+            {
+                if (Pass(in s1[i], in s2[i], in s3[i], in s4[i])) Included(ref s1[i], ref s2[i], ref s3[i], ref s4[i]);
+            }
+            return;
+        }
+
         for (var i = 0; i < Memory1.Length; i++)
         {
             if (Pass(in s1[i], in s2[i], in s3[i], in s4[i])) Included(ref s1[i], ref s2[i], ref s3[i], ref s4[i]);
-            else Excluded(ref s1[i], ref s2[i], ref s3[i], ref s4[i]);
+            else excluded(ref s1[i], ref s2[i], ref s3[i], ref s4[i]);
         }
     }
 }
@@ -365,7 +625,7 @@ internal class UniformDualWork<U, C1, C2, C3, C4> : Workload
     public Memory<C4> Memory4 = null!;
     public FilterDelegate<C1, C2, C3, C4> Pass = null!;
     public UniformComponentAction<U, C1, C2, C3, C4> Included = null!;
-    public UniformComponentAction<U, C1, C2, C3, C4> Excluded = null!;
+    public UniformComponentAction<U, C1, C2, C3, C4>? Excluded;
     public U Uniform = default!;
 
     protected override void Run()
@@ -374,10 +634,20 @@ internal class UniformDualWork<U, C1, C2, C3, C4> : Workload
         var s2 = Memory2.Span;
         var s3 = Memory3.Span;
         var s4 = Memory4.Span;
+        var excluded = Excluded;
+        if (excluded is null)
+        {
+            for (var i = 0; i < Memory1.Length; i++)
+            {
+                if (Pass(in s1[i], in s2[i], in s3[i], in s4[i])) Included(Uniform, ref s1[i], ref s2[i], ref s3[i], ref s4[i]);
+            }
+            return;
+        }
+
         for (var i = 0; i < Memory1.Length; i++)
         {
             if (Pass(in s1[i], in s2[i], in s3[i], in s4[i])) Included(Uniform, ref s1[i], ref s2[i], ref s3[i], ref s4[i]);
-            else Excluded(Uniform, ref s1[i], ref s2[i], ref s3[i], ref s4[i]);
+            else excluded(Uniform, ref s1[i], ref s2[i], ref s3[i], ref s4[i]);
         }
     }
 }
@@ -389,12 +659,37 @@ internal class Work<C1, C2, C3, C4, C5> : Workload
     public Memory<C3> Memory3 = null!;
     public Memory<C4> Memory4 = null!;
     public Memory<C5> Memory5 = null!;
+    public pools.PooledList<(Memory<C1>, Memory<C2>, Memory<C3>, Memory<C4>, Memory<C5>)>? Segments;
 
     public ComponentAction<C1, C2, C3, C4, C5> Action = null!;
 
 
     protected override void Run()
     {
+        if (Segments is { } segments)
+        {
+            List<Exception>? faults = null;
+            foreach (var (memory1, memory2, memory3, memory4, memory5) in segments)
+            {
+                try
+                {
+                    var segment1 = memory1.Span;
+                    var segment2 = memory2.Span;
+                    var segment3 = memory3.Span;
+                    var segment4 = memory4.Span;
+                    var segment5 = memory5.Span;
+                    for (var i = 0; i < segment1.Length; i++)
+                        Action(ref segment1[i], ref segment2[i], ref segment3[i], ref segment4[i], ref segment5[i]);
+                }
+                catch (Exception exception)
+                {
+                    (faults ??= []).Add(exception);
+                }
+            }
+            RethrowSegmentFaults(faults);
+            return;
+        }
+
         var s1 = Memory1.Span;
         var s2 = Memory2.Span;
         var s3 = Memory3.Span;
@@ -415,6 +710,7 @@ internal class UniformWork<U, C1, C2, C3, C4, C5> : Workload
     public Memory<C3> Memory3 = null!;
     public Memory<C4> Memory4 = null!;
     public Memory<C5> Memory5 = null!;
+    public pools.PooledList<(Memory<C1>, Memory<C2>, Memory<C3>, Memory<C4>, Memory<C5>)>? Segments;
 
     public UniformComponentAction<U, C1, C2, C3, C4, C5> Action = null!;
     public U Uniform = default!;
@@ -422,6 +718,31 @@ internal class UniformWork<U, C1, C2, C3, C4, C5> : Workload
 
     protected override void Run()
     {
+        if (Segments is { } segments)
+        {
+            List<Exception>? faults = null;
+            foreach (var (memory1, memory2, memory3, memory4, memory5) in segments)
+            {
+                try
+                {
+                    var segment1 = memory1.Span;
+                    var segment2 = memory2.Span;
+                    var segment3 = memory3.Span;
+                    var segment4 = memory4.Span;
+                    var segment5 = memory5.Span;
+                    for (var i = 0; i < segment1.Length; i++)
+                        Action(Uniform, ref segment1[i], ref segment2[i], ref segment3[i], ref segment4[i],
+                            ref segment5[i]);
+                }
+                catch (Exception exception)
+                {
+                    (faults ??= []).Add(exception);
+                }
+            }
+            RethrowSegmentFaults(faults);
+            return;
+        }
+
         var s1 = Memory1.Span;
         var s2 = Memory2.Span;
         var s3 = Memory3.Span;
@@ -444,7 +765,7 @@ internal class DualWork<C1, C2, C3, C4, C5> : Workload
     public Memory<C5> Memory5 = null!;
     public FilterDelegate<C1, C2, C3, C4, C5> Pass = null!;
     public ComponentAction<C1, C2, C3, C4, C5> Included = null!;
-    public ComponentAction<C1, C2, C3, C4, C5> Excluded = null!;
+    public ComponentAction<C1, C2, C3, C4, C5>? Excluded;
 
     protected override void Run()
     {
@@ -453,10 +774,20 @@ internal class DualWork<C1, C2, C3, C4, C5> : Workload
         var s3 = Memory3.Span;
         var s4 = Memory4.Span;
         var s5 = Memory5.Span;
+        var excluded = Excluded;
+        if (excluded is null)
+        {
+            for (var i = 0; i < Memory1.Length; i++)
+            {
+                if (Pass(in s1[i], in s2[i], in s3[i], in s4[i], in s5[i])) Included(ref s1[i], ref s2[i], ref s3[i], ref s4[i], ref s5[i]);
+            }
+            return;
+        }
+
         for (var i = 0; i < Memory1.Length; i++)
         {
             if (Pass(in s1[i], in s2[i], in s3[i], in s4[i], in s5[i])) Included(ref s1[i], ref s2[i], ref s3[i], ref s4[i], ref s5[i]);
-            else Excluded(ref s1[i], ref s2[i], ref s3[i], ref s4[i], ref s5[i]);
+            else excluded(ref s1[i], ref s2[i], ref s3[i], ref s4[i], ref s5[i]);
         }
     }
 }
@@ -470,7 +801,7 @@ internal class UniformDualWork<U, C1, C2, C3, C4, C5> : Workload
     public Memory<C5> Memory5 = null!;
     public FilterDelegate<C1, C2, C3, C4, C5> Pass = null!;
     public UniformComponentAction<U, C1, C2, C3, C4, C5> Included = null!;
-    public UniformComponentAction<U, C1, C2, C3, C4, C5> Excluded = null!;
+    public UniformComponentAction<U, C1, C2, C3, C4, C5>? Excluded;
     public U Uniform = default!;
 
     protected override void Run()
@@ -480,10 +811,20 @@ internal class UniformDualWork<U, C1, C2, C3, C4, C5> : Workload
         var s3 = Memory3.Span;
         var s4 = Memory4.Span;
         var s5 = Memory5.Span;
+        var excluded = Excluded;
+        if (excluded is null)
+        {
+            for (var i = 0; i < Memory1.Length; i++)
+            {
+                if (Pass(in s1[i], in s2[i], in s3[i], in s4[i], in s5[i])) Included(Uniform, ref s1[i], ref s2[i], ref s3[i], ref s4[i], ref s5[i]);
+            }
+            return;
+        }
+
         for (var i = 0; i < Memory1.Length; i++)
         {
             if (Pass(in s1[i], in s2[i], in s3[i], in s4[i], in s5[i])) Included(Uniform, ref s1[i], ref s2[i], ref s3[i], ref s4[i], ref s5[i]);
-            else Excluded(Uniform, ref s1[i], ref s2[i], ref s3[i], ref s4[i], ref s5[i]);
+            else excluded(Uniform, ref s1[i], ref s2[i], ref s3[i], ref s4[i], ref s5[i]);
         }
     }
 }

--- a/src/fennecs/generators/FilteredStream.generated.cs
+++ b/src/fennecs/generators/FilteredStream.generated.cs
@@ -328,6 +328,7 @@ namespace fennecs
 
             using var countdown = new CountdownEvent(initialCount: 1);
             using var jobs = PooledList<DualWork<C0>>.Rent();
+            FilterDelegate<C0> pass = Pass;
 
             foreach (var table in Archetypes)
             {
@@ -349,8 +350,8 @@ namespace fennecs
                         var job = JobPool<DualWork<C0>>.Rent();
                         job.Memory1 = s0.AsMemory(start, length);
                         job.Included = action;
-                        job.Excluded = NoOp;
-                        job.Pass = Pass;
+                        job.Excluded = null;
+                        job.Pass = pass;
                         job.CountDown = countdown;
                         jobs.Add(job);
 
@@ -363,6 +364,14 @@ namespace fennecs
 
             List<Exception>? faults = null;
             Workloads.CollectFaults(ref faults, jobs);
+            foreach (var job in jobs)
+            {
+                job.Memory1 = default;
+                job.Pass = null!;
+                job.Included = null!;
+                job.Excluded = null;
+                job.CountDown = null!;
+            }
             JobPool<DualWork<C0>>.Return(jobs);
             Workloads.Rethrow(faults);
         }
@@ -377,8 +386,7 @@ namespace fennecs
 
             using var countdown = new CountdownEvent(initialCount: 1);
             using var jobs = PooledList<UniformDualWork<U, C0>>.Rent();
-
-            UniformComponentAction<U, C0> noOp = static (U _, ref C0 _) => { };
+            FilterDelegate<C0> pass = Pass;
 
             foreach (var table in Archetypes)
             {
@@ -400,8 +408,8 @@ namespace fennecs
                         var job = JobPool<UniformDualWork<U, C0>>.Rent();
                         job.Memory1 = s0.AsMemory(start, length);
                         job.Included = action;
-                        job.Excluded = noOp;
-                        job.Pass = Pass;
+                        job.Excluded = null;
+                        job.Pass = pass;
                         job.Uniform = uniform;
                         job.CountDown = countdown;
                         jobs.Add(job);
@@ -415,6 +423,15 @@ namespace fennecs
 
             List<Exception>? faults = null;
             Workloads.CollectFaults(ref faults, jobs);
+            foreach (var job in jobs)
+            {
+                job.Memory1 = default;
+                job.Pass = null!;
+                job.Included = null!;
+                job.Excluded = null;
+                job.Uniform = default!;
+                job.CountDown = null!;
+            }
             JobPool<UniformDualWork<U, C0>>.Return(jobs);
             Workloads.Rethrow(faults);
         }
@@ -441,6 +458,7 @@ namespace fennecs
             using var countdown = new CountdownEvent(initialCount: 1);
             using var dualJobs = PooledList<DualWork<C0>>.Rent();
             using var plainJobs = PooledList<Work<C0>>.Rent();
+            FilterDelegate<C0> pass = Pass;
 
             foreach (var table in Archetypes)
             {
@@ -465,7 +483,7 @@ namespace fennecs
                             job.Memory1 = s0.AsMemory(start, length);
                             job.Included = included;
                             job.Excluded = excluded;
-                            job.Pass = Pass;
+                            job.Pass = pass;
                             job.CountDown = countdown;
                             dualJobs.Add(job);
 
@@ -490,6 +508,20 @@ namespace fennecs
             List<Exception>? faults = null;
             Workloads.CollectFaults(ref faults, dualJobs);
             Workloads.CollectFaults(ref faults, plainJobs);
+            foreach (var job in dualJobs)
+            {
+                job.Memory1 = default;
+                job.Pass = null!;
+                job.Included = null!;
+                job.Excluded = null;
+                job.CountDown = null!;
+            }
+            foreach (var job in plainJobs)
+            {
+                job.Memory1 = default;
+                job.Action = null!;
+                job.CountDown = null!;
+            }
             JobPool<DualWork<C0>>.Return(dualJobs);
             JobPool<Work<C0>>.Return(plainJobs);
             Workloads.Rethrow(faults);
@@ -506,6 +538,7 @@ namespace fennecs
             using var countdown = new CountdownEvent(initialCount: 1);
             using var dualJobs = PooledList<UniformDualWork<U, C0>>.Rent();
             using var plainJobs = PooledList<UniformWork<U, C0>>.Rent();
+            FilterDelegate<C0> pass = Pass;
 
             foreach (var table in Archetypes)
             {
@@ -530,7 +563,7 @@ namespace fennecs
                             job.Memory1 = s0.AsMemory(start, length);
                             job.Included = included;
                             job.Excluded = excluded;
-                            job.Pass = Pass;
+                            job.Pass = pass;
                             job.Uniform = uniform;
                             job.CountDown = countdown;
                             dualJobs.Add(job);
@@ -557,6 +590,22 @@ namespace fennecs
             List<Exception>? faults = null;
             Workloads.CollectFaults(ref faults, dualJobs);
             Workloads.CollectFaults(ref faults, plainJobs);
+            foreach (var job in dualJobs)
+            {
+                job.Memory1 = default;
+                job.Pass = null!;
+                job.Included = null!;
+                job.Excluded = null;
+                job.Uniform = default!;
+                job.CountDown = null!;
+            }
+            foreach (var job in plainJobs)
+            {
+                job.Memory1 = default;
+                job.Action = null!;
+                job.Uniform = default!;
+                job.CountDown = null!;
+            }
             JobPool<UniformDualWork<U, C0>>.Return(dualJobs);
             JobPool<UniformWork<U, C0>>.Return(plainJobs);
             Workloads.Rethrow(faults);
@@ -777,8 +826,6 @@ namespace fennecs
                 return sum;
             }
         }
-
-        private static readonly ComponentAction<C0> NoOp = static (ref C0 _) => { };
 
         private bool HasWildcards => Stream.StreamTypes.Any(type => type.isWildcard);
 
@@ -1122,6 +1169,7 @@ namespace fennecs
 
             using var countdown = new CountdownEvent(initialCount: 1);
             using var jobs = PooledList<DualWork<C0, C1>>.Rent();
+            FilterDelegate<C0, C1> pass = Pass;
 
             foreach (var table in Archetypes)
             {
@@ -1144,8 +1192,8 @@ namespace fennecs
                         job.Memory1 = s0.AsMemory(start, length);
                         job.Memory2 = s1.AsMemory(start, length);
                         job.Included = action;
-                        job.Excluded = NoOp;
-                        job.Pass = Pass;
+                        job.Excluded = null;
+                        job.Pass = pass;
                         job.CountDown = countdown;
                         jobs.Add(job);
 
@@ -1158,6 +1206,15 @@ namespace fennecs
 
             List<Exception>? faults = null;
             Workloads.CollectFaults(ref faults, jobs);
+            foreach (var job in jobs)
+            {
+                job.Memory1 = default;
+                job.Memory2 = default;
+                job.Pass = null!;
+                job.Included = null!;
+                job.Excluded = null;
+                job.CountDown = null!;
+            }
             JobPool<DualWork<C0, C1>>.Return(jobs);
             Workloads.Rethrow(faults);
         }
@@ -1172,8 +1229,7 @@ namespace fennecs
 
             using var countdown = new CountdownEvent(initialCount: 1);
             using var jobs = PooledList<UniformDualWork<U, C0, C1>>.Rent();
-
-            UniformComponentAction<U, C0, C1> noOp = static (U _, ref C0 _, ref C1 _) => { };
+            FilterDelegate<C0, C1> pass = Pass;
 
             foreach (var table in Archetypes)
             {
@@ -1196,8 +1252,8 @@ namespace fennecs
                         job.Memory1 = s0.AsMemory(start, length);
                         job.Memory2 = s1.AsMemory(start, length);
                         job.Included = action;
-                        job.Excluded = noOp;
-                        job.Pass = Pass;
+                        job.Excluded = null;
+                        job.Pass = pass;
                         job.Uniform = uniform;
                         job.CountDown = countdown;
                         jobs.Add(job);
@@ -1211,6 +1267,16 @@ namespace fennecs
 
             List<Exception>? faults = null;
             Workloads.CollectFaults(ref faults, jobs);
+            foreach (var job in jobs)
+            {
+                job.Memory1 = default;
+                job.Memory2 = default;
+                job.Pass = null!;
+                job.Included = null!;
+                job.Excluded = null;
+                job.Uniform = default!;
+                job.CountDown = null!;
+            }
             JobPool<UniformDualWork<U, C0, C1>>.Return(jobs);
             Workloads.Rethrow(faults);
         }
@@ -1237,6 +1303,7 @@ namespace fennecs
             using var countdown = new CountdownEvent(initialCount: 1);
             using var dualJobs = PooledList<DualWork<C0, C1>>.Rent();
             using var plainJobs = PooledList<Work<C0, C1>>.Rent();
+            FilterDelegate<C0, C1> pass = Pass;
 
             foreach (var table in Archetypes)
             {
@@ -1262,7 +1329,7 @@ namespace fennecs
                             job.Memory2 = s1.AsMemory(start, length);
                             job.Included = included;
                             job.Excluded = excluded;
-                            job.Pass = Pass;
+                            job.Pass = pass;
                             job.CountDown = countdown;
                             dualJobs.Add(job);
 
@@ -1288,6 +1355,22 @@ namespace fennecs
             List<Exception>? faults = null;
             Workloads.CollectFaults(ref faults, dualJobs);
             Workloads.CollectFaults(ref faults, plainJobs);
+            foreach (var job in dualJobs)
+            {
+                job.Memory1 = default;
+                job.Memory2 = default;
+                job.Pass = null!;
+                job.Included = null!;
+                job.Excluded = null;
+                job.CountDown = null!;
+            }
+            foreach (var job in plainJobs)
+            {
+                job.Memory1 = default;
+                job.Memory2 = default;
+                job.Action = null!;
+                job.CountDown = null!;
+            }
             JobPool<DualWork<C0, C1>>.Return(dualJobs);
             JobPool<Work<C0, C1>>.Return(plainJobs);
             Workloads.Rethrow(faults);
@@ -1304,6 +1387,7 @@ namespace fennecs
             using var countdown = new CountdownEvent(initialCount: 1);
             using var dualJobs = PooledList<UniformDualWork<U, C0, C1>>.Rent();
             using var plainJobs = PooledList<UniformWork<U, C0, C1>>.Rent();
+            FilterDelegate<C0, C1> pass = Pass;
 
             foreach (var table in Archetypes)
             {
@@ -1329,7 +1413,7 @@ namespace fennecs
                             job.Memory2 = s1.AsMemory(start, length);
                             job.Included = included;
                             job.Excluded = excluded;
-                            job.Pass = Pass;
+                            job.Pass = pass;
                             job.Uniform = uniform;
                             job.CountDown = countdown;
                             dualJobs.Add(job);
@@ -1357,6 +1441,24 @@ namespace fennecs
             List<Exception>? faults = null;
             Workloads.CollectFaults(ref faults, dualJobs);
             Workloads.CollectFaults(ref faults, plainJobs);
+            foreach (var job in dualJobs)
+            {
+                job.Memory1 = default;
+                job.Memory2 = default;
+                job.Pass = null!;
+                job.Included = null!;
+                job.Excluded = null;
+                job.Uniform = default!;
+                job.CountDown = null!;
+            }
+            foreach (var job in plainJobs)
+            {
+                job.Memory1 = default;
+                job.Memory2 = default;
+                job.Action = null!;
+                job.Uniform = default!;
+                job.CountDown = null!;
+            }
             JobPool<UniformDualWork<U, C0, C1>>.Return(dualJobs);
             JobPool<UniformWork<U, C0, C1>>.Return(plainJobs);
             Workloads.Rethrow(faults);
@@ -1577,8 +1679,6 @@ namespace fennecs
                 return sum;
             }
         }
-
-        private static readonly ComponentAction<C0, C1> NoOp = static (ref C0 _, ref C1 _) => { };
 
         private bool HasWildcards => Stream.StreamTypes.Any(type => type.isWildcard);
 
@@ -1933,6 +2033,7 @@ namespace fennecs
 
             using var countdown = new CountdownEvent(initialCount: 1);
             using var jobs = PooledList<DualWork<C0, C1, C2>>.Rent();
+            FilterDelegate<C0, C1, C2> pass = Pass;
 
             foreach (var table in Archetypes)
             {
@@ -1956,8 +2057,8 @@ namespace fennecs
                         job.Memory2 = s1.AsMemory(start, length);
                         job.Memory3 = s2.AsMemory(start, length);
                         job.Included = action;
-                        job.Excluded = NoOp;
-                        job.Pass = Pass;
+                        job.Excluded = null;
+                        job.Pass = pass;
                         job.CountDown = countdown;
                         jobs.Add(job);
 
@@ -1970,6 +2071,16 @@ namespace fennecs
 
             List<Exception>? faults = null;
             Workloads.CollectFaults(ref faults, jobs);
+            foreach (var job in jobs)
+            {
+                job.Memory1 = default;
+                job.Memory2 = default;
+                job.Memory3 = default;
+                job.Pass = null!;
+                job.Included = null!;
+                job.Excluded = null;
+                job.CountDown = null!;
+            }
             JobPool<DualWork<C0, C1, C2>>.Return(jobs);
             Workloads.Rethrow(faults);
         }
@@ -1984,8 +2095,7 @@ namespace fennecs
 
             using var countdown = new CountdownEvent(initialCount: 1);
             using var jobs = PooledList<UniformDualWork<U, C0, C1, C2>>.Rent();
-
-            UniformComponentAction<U, C0, C1, C2> noOp = static (U _, ref C0 _, ref C1 _, ref C2 _) => { };
+            FilterDelegate<C0, C1, C2> pass = Pass;
 
             foreach (var table in Archetypes)
             {
@@ -2009,8 +2119,8 @@ namespace fennecs
                         job.Memory2 = s1.AsMemory(start, length);
                         job.Memory3 = s2.AsMemory(start, length);
                         job.Included = action;
-                        job.Excluded = noOp;
-                        job.Pass = Pass;
+                        job.Excluded = null;
+                        job.Pass = pass;
                         job.Uniform = uniform;
                         job.CountDown = countdown;
                         jobs.Add(job);
@@ -2024,6 +2134,17 @@ namespace fennecs
 
             List<Exception>? faults = null;
             Workloads.CollectFaults(ref faults, jobs);
+            foreach (var job in jobs)
+            {
+                job.Memory1 = default;
+                job.Memory2 = default;
+                job.Memory3 = default;
+                job.Pass = null!;
+                job.Included = null!;
+                job.Excluded = null;
+                job.Uniform = default!;
+                job.CountDown = null!;
+            }
             JobPool<UniformDualWork<U, C0, C1, C2>>.Return(jobs);
             Workloads.Rethrow(faults);
         }
@@ -2050,6 +2171,7 @@ namespace fennecs
             using var countdown = new CountdownEvent(initialCount: 1);
             using var dualJobs = PooledList<DualWork<C0, C1, C2>>.Rent();
             using var plainJobs = PooledList<Work<C0, C1, C2>>.Rent();
+            FilterDelegate<C0, C1, C2> pass = Pass;
 
             foreach (var table in Archetypes)
             {
@@ -2076,7 +2198,7 @@ namespace fennecs
                             job.Memory3 = s2.AsMemory(start, length);
                             job.Included = included;
                             job.Excluded = excluded;
-                            job.Pass = Pass;
+                            job.Pass = pass;
                             job.CountDown = countdown;
                             dualJobs.Add(job);
 
@@ -2103,6 +2225,24 @@ namespace fennecs
             List<Exception>? faults = null;
             Workloads.CollectFaults(ref faults, dualJobs);
             Workloads.CollectFaults(ref faults, plainJobs);
+            foreach (var job in dualJobs)
+            {
+                job.Memory1 = default;
+                job.Memory2 = default;
+                job.Memory3 = default;
+                job.Pass = null!;
+                job.Included = null!;
+                job.Excluded = null;
+                job.CountDown = null!;
+            }
+            foreach (var job in plainJobs)
+            {
+                job.Memory1 = default;
+                job.Memory2 = default;
+                job.Memory3 = default;
+                job.Action = null!;
+                job.CountDown = null!;
+            }
             JobPool<DualWork<C0, C1, C2>>.Return(dualJobs);
             JobPool<Work<C0, C1, C2>>.Return(plainJobs);
             Workloads.Rethrow(faults);
@@ -2119,6 +2259,7 @@ namespace fennecs
             using var countdown = new CountdownEvent(initialCount: 1);
             using var dualJobs = PooledList<UniformDualWork<U, C0, C1, C2>>.Rent();
             using var plainJobs = PooledList<UniformWork<U, C0, C1, C2>>.Rent();
+            FilterDelegate<C0, C1, C2> pass = Pass;
 
             foreach (var table in Archetypes)
             {
@@ -2145,7 +2286,7 @@ namespace fennecs
                             job.Memory3 = s2.AsMemory(start, length);
                             job.Included = included;
                             job.Excluded = excluded;
-                            job.Pass = Pass;
+                            job.Pass = pass;
                             job.Uniform = uniform;
                             job.CountDown = countdown;
                             dualJobs.Add(job);
@@ -2174,6 +2315,26 @@ namespace fennecs
             List<Exception>? faults = null;
             Workloads.CollectFaults(ref faults, dualJobs);
             Workloads.CollectFaults(ref faults, plainJobs);
+            foreach (var job in dualJobs)
+            {
+                job.Memory1 = default;
+                job.Memory2 = default;
+                job.Memory3 = default;
+                job.Pass = null!;
+                job.Included = null!;
+                job.Excluded = null;
+                job.Uniform = default!;
+                job.CountDown = null!;
+            }
+            foreach (var job in plainJobs)
+            {
+                job.Memory1 = default;
+                job.Memory2 = default;
+                job.Memory3 = default;
+                job.Action = null!;
+                job.Uniform = default!;
+                job.CountDown = null!;
+            }
             JobPool<UniformDualWork<U, C0, C1, C2>>.Return(dualJobs);
             JobPool<UniformWork<U, C0, C1, C2>>.Return(plainJobs);
             Workloads.Rethrow(faults);
@@ -2394,8 +2555,6 @@ namespace fennecs
                 return sum;
             }
         }
-
-        private static readonly ComponentAction<C0, C1, C2> NoOp = static (ref C0 _, ref C1 _, ref C2 _) => { };
 
         private bool HasWildcards => Stream.StreamTypes.Any(type => type.isWildcard);
 
@@ -2761,6 +2920,7 @@ namespace fennecs
 
             using var countdown = new CountdownEvent(initialCount: 1);
             using var jobs = PooledList<DualWork<C0, C1, C2, C3>>.Rent();
+            FilterDelegate<C0, C1, C2, C3> pass = Pass;
 
             foreach (var table in Archetypes)
             {
@@ -2785,8 +2945,8 @@ namespace fennecs
                         job.Memory3 = s2.AsMemory(start, length);
                         job.Memory4 = s3.AsMemory(start, length);
                         job.Included = action;
-                        job.Excluded = NoOp;
-                        job.Pass = Pass;
+                        job.Excluded = null;
+                        job.Pass = pass;
                         job.CountDown = countdown;
                         jobs.Add(job);
 
@@ -2799,6 +2959,17 @@ namespace fennecs
 
             List<Exception>? faults = null;
             Workloads.CollectFaults(ref faults, jobs);
+            foreach (var job in jobs)
+            {
+                job.Memory1 = default;
+                job.Memory2 = default;
+                job.Memory3 = default;
+                job.Memory4 = default;
+                job.Pass = null!;
+                job.Included = null!;
+                job.Excluded = null;
+                job.CountDown = null!;
+            }
             JobPool<DualWork<C0, C1, C2, C3>>.Return(jobs);
             Workloads.Rethrow(faults);
         }
@@ -2813,8 +2984,7 @@ namespace fennecs
 
             using var countdown = new CountdownEvent(initialCount: 1);
             using var jobs = PooledList<UniformDualWork<U, C0, C1, C2, C3>>.Rent();
-
-            UniformComponentAction<U, C0, C1, C2, C3> noOp = static (U _, ref C0 _, ref C1 _, ref C2 _, ref C3 _) => { };
+            FilterDelegate<C0, C1, C2, C3> pass = Pass;
 
             foreach (var table in Archetypes)
             {
@@ -2839,8 +3009,8 @@ namespace fennecs
                         job.Memory3 = s2.AsMemory(start, length);
                         job.Memory4 = s3.AsMemory(start, length);
                         job.Included = action;
-                        job.Excluded = noOp;
-                        job.Pass = Pass;
+                        job.Excluded = null;
+                        job.Pass = pass;
                         job.Uniform = uniform;
                         job.CountDown = countdown;
                         jobs.Add(job);
@@ -2854,6 +3024,18 @@ namespace fennecs
 
             List<Exception>? faults = null;
             Workloads.CollectFaults(ref faults, jobs);
+            foreach (var job in jobs)
+            {
+                job.Memory1 = default;
+                job.Memory2 = default;
+                job.Memory3 = default;
+                job.Memory4 = default;
+                job.Pass = null!;
+                job.Included = null!;
+                job.Excluded = null;
+                job.Uniform = default!;
+                job.CountDown = null!;
+            }
             JobPool<UniformDualWork<U, C0, C1, C2, C3>>.Return(jobs);
             Workloads.Rethrow(faults);
         }
@@ -2880,6 +3062,7 @@ namespace fennecs
             using var countdown = new CountdownEvent(initialCount: 1);
             using var dualJobs = PooledList<DualWork<C0, C1, C2, C3>>.Rent();
             using var plainJobs = PooledList<Work<C0, C1, C2, C3>>.Rent();
+            FilterDelegate<C0, C1, C2, C3> pass = Pass;
 
             foreach (var table in Archetypes)
             {
@@ -2907,7 +3090,7 @@ namespace fennecs
                             job.Memory4 = s3.AsMemory(start, length);
                             job.Included = included;
                             job.Excluded = excluded;
-                            job.Pass = Pass;
+                            job.Pass = pass;
                             job.CountDown = countdown;
                             dualJobs.Add(job);
 
@@ -2935,6 +3118,26 @@ namespace fennecs
             List<Exception>? faults = null;
             Workloads.CollectFaults(ref faults, dualJobs);
             Workloads.CollectFaults(ref faults, plainJobs);
+            foreach (var job in dualJobs)
+            {
+                job.Memory1 = default;
+                job.Memory2 = default;
+                job.Memory3 = default;
+                job.Memory4 = default;
+                job.Pass = null!;
+                job.Included = null!;
+                job.Excluded = null;
+                job.CountDown = null!;
+            }
+            foreach (var job in plainJobs)
+            {
+                job.Memory1 = default;
+                job.Memory2 = default;
+                job.Memory3 = default;
+                job.Memory4 = default;
+                job.Action = null!;
+                job.CountDown = null!;
+            }
             JobPool<DualWork<C0, C1, C2, C3>>.Return(dualJobs);
             JobPool<Work<C0, C1, C2, C3>>.Return(plainJobs);
             Workloads.Rethrow(faults);
@@ -2951,6 +3154,7 @@ namespace fennecs
             using var countdown = new CountdownEvent(initialCount: 1);
             using var dualJobs = PooledList<UniformDualWork<U, C0, C1, C2, C3>>.Rent();
             using var plainJobs = PooledList<UniformWork<U, C0, C1, C2, C3>>.Rent();
+            FilterDelegate<C0, C1, C2, C3> pass = Pass;
 
             foreach (var table in Archetypes)
             {
@@ -2978,7 +3182,7 @@ namespace fennecs
                             job.Memory4 = s3.AsMemory(start, length);
                             job.Included = included;
                             job.Excluded = excluded;
-                            job.Pass = Pass;
+                            job.Pass = pass;
                             job.Uniform = uniform;
                             job.CountDown = countdown;
                             dualJobs.Add(job);
@@ -3008,6 +3212,28 @@ namespace fennecs
             List<Exception>? faults = null;
             Workloads.CollectFaults(ref faults, dualJobs);
             Workloads.CollectFaults(ref faults, plainJobs);
+            foreach (var job in dualJobs)
+            {
+                job.Memory1 = default;
+                job.Memory2 = default;
+                job.Memory3 = default;
+                job.Memory4 = default;
+                job.Pass = null!;
+                job.Included = null!;
+                job.Excluded = null;
+                job.Uniform = default!;
+                job.CountDown = null!;
+            }
+            foreach (var job in plainJobs)
+            {
+                job.Memory1 = default;
+                job.Memory2 = default;
+                job.Memory3 = default;
+                job.Memory4 = default;
+                job.Action = null!;
+                job.Uniform = default!;
+                job.CountDown = null!;
+            }
             JobPool<UniformDualWork<U, C0, C1, C2, C3>>.Return(dualJobs);
             JobPool<UniformWork<U, C0, C1, C2, C3>>.Return(plainJobs);
             Workloads.Rethrow(faults);
@@ -3228,8 +3454,6 @@ namespace fennecs
                 return sum;
             }
         }
-
-        private static readonly ComponentAction<C0, C1, C2, C3> NoOp = static (ref C0 _, ref C1 _, ref C2 _, ref C3 _) => { };
 
         private bool HasWildcards => Stream.StreamTypes.Any(type => type.isWildcard);
 
@@ -3606,6 +3830,7 @@ namespace fennecs
 
             using var countdown = new CountdownEvent(initialCount: 1);
             using var jobs = PooledList<DualWork<C0, C1, C2, C3, C4>>.Rent();
+            FilterDelegate<C0, C1, C2, C3, C4> pass = Pass;
 
             foreach (var table in Archetypes)
             {
@@ -3631,8 +3856,8 @@ namespace fennecs
                         job.Memory4 = s3.AsMemory(start, length);
                         job.Memory5 = s4.AsMemory(start, length);
                         job.Included = action;
-                        job.Excluded = NoOp;
-                        job.Pass = Pass;
+                        job.Excluded = null;
+                        job.Pass = pass;
                         job.CountDown = countdown;
                         jobs.Add(job);
 
@@ -3645,6 +3870,18 @@ namespace fennecs
 
             List<Exception>? faults = null;
             Workloads.CollectFaults(ref faults, jobs);
+            foreach (var job in jobs)
+            {
+                job.Memory1 = default;
+                job.Memory2 = default;
+                job.Memory3 = default;
+                job.Memory4 = default;
+                job.Memory5 = default;
+                job.Pass = null!;
+                job.Included = null!;
+                job.Excluded = null;
+                job.CountDown = null!;
+            }
             JobPool<DualWork<C0, C1, C2, C3, C4>>.Return(jobs);
             Workloads.Rethrow(faults);
         }
@@ -3659,8 +3896,7 @@ namespace fennecs
 
             using var countdown = new CountdownEvent(initialCount: 1);
             using var jobs = PooledList<UniformDualWork<U, C0, C1, C2, C3, C4>>.Rent();
-
-            UniformComponentAction<U, C0, C1, C2, C3, C4> noOp = static (U _, ref C0 _, ref C1 _, ref C2 _, ref C3 _, ref C4 _) => { };
+            FilterDelegate<C0, C1, C2, C3, C4> pass = Pass;
 
             foreach (var table in Archetypes)
             {
@@ -3686,8 +3922,8 @@ namespace fennecs
                         job.Memory4 = s3.AsMemory(start, length);
                         job.Memory5 = s4.AsMemory(start, length);
                         job.Included = action;
-                        job.Excluded = noOp;
-                        job.Pass = Pass;
+                        job.Excluded = null;
+                        job.Pass = pass;
                         job.Uniform = uniform;
                         job.CountDown = countdown;
                         jobs.Add(job);
@@ -3701,6 +3937,19 @@ namespace fennecs
 
             List<Exception>? faults = null;
             Workloads.CollectFaults(ref faults, jobs);
+            foreach (var job in jobs)
+            {
+                job.Memory1 = default;
+                job.Memory2 = default;
+                job.Memory3 = default;
+                job.Memory4 = default;
+                job.Memory5 = default;
+                job.Pass = null!;
+                job.Included = null!;
+                job.Excluded = null;
+                job.Uniform = default!;
+                job.CountDown = null!;
+            }
             JobPool<UniformDualWork<U, C0, C1, C2, C3, C4>>.Return(jobs);
             Workloads.Rethrow(faults);
         }
@@ -3727,6 +3976,7 @@ namespace fennecs
             using var countdown = new CountdownEvent(initialCount: 1);
             using var dualJobs = PooledList<DualWork<C0, C1, C2, C3, C4>>.Rent();
             using var plainJobs = PooledList<Work<C0, C1, C2, C3, C4>>.Rent();
+            FilterDelegate<C0, C1, C2, C3, C4> pass = Pass;
 
             foreach (var table in Archetypes)
             {
@@ -3755,7 +4005,7 @@ namespace fennecs
                             job.Memory5 = s4.AsMemory(start, length);
                             job.Included = included;
                             job.Excluded = excluded;
-                            job.Pass = Pass;
+                            job.Pass = pass;
                             job.CountDown = countdown;
                             dualJobs.Add(job);
 
@@ -3784,6 +4034,28 @@ namespace fennecs
             List<Exception>? faults = null;
             Workloads.CollectFaults(ref faults, dualJobs);
             Workloads.CollectFaults(ref faults, plainJobs);
+            foreach (var job in dualJobs)
+            {
+                job.Memory1 = default;
+                job.Memory2 = default;
+                job.Memory3 = default;
+                job.Memory4 = default;
+                job.Memory5 = default;
+                job.Pass = null!;
+                job.Included = null!;
+                job.Excluded = null;
+                job.CountDown = null!;
+            }
+            foreach (var job in plainJobs)
+            {
+                job.Memory1 = default;
+                job.Memory2 = default;
+                job.Memory3 = default;
+                job.Memory4 = default;
+                job.Memory5 = default;
+                job.Action = null!;
+                job.CountDown = null!;
+            }
             JobPool<DualWork<C0, C1, C2, C3, C4>>.Return(dualJobs);
             JobPool<Work<C0, C1, C2, C3, C4>>.Return(plainJobs);
             Workloads.Rethrow(faults);
@@ -3800,6 +4072,7 @@ namespace fennecs
             using var countdown = new CountdownEvent(initialCount: 1);
             using var dualJobs = PooledList<UniformDualWork<U, C0, C1, C2, C3, C4>>.Rent();
             using var plainJobs = PooledList<UniformWork<U, C0, C1, C2, C3, C4>>.Rent();
+            FilterDelegate<C0, C1, C2, C3, C4> pass = Pass;
 
             foreach (var table in Archetypes)
             {
@@ -3828,7 +4101,7 @@ namespace fennecs
                             job.Memory5 = s4.AsMemory(start, length);
                             job.Included = included;
                             job.Excluded = excluded;
-                            job.Pass = Pass;
+                            job.Pass = pass;
                             job.Uniform = uniform;
                             job.CountDown = countdown;
                             dualJobs.Add(job);
@@ -3859,6 +4132,30 @@ namespace fennecs
             List<Exception>? faults = null;
             Workloads.CollectFaults(ref faults, dualJobs);
             Workloads.CollectFaults(ref faults, plainJobs);
+            foreach (var job in dualJobs)
+            {
+                job.Memory1 = default;
+                job.Memory2 = default;
+                job.Memory3 = default;
+                job.Memory4 = default;
+                job.Memory5 = default;
+                job.Pass = null!;
+                job.Included = null!;
+                job.Excluded = null;
+                job.Uniform = default!;
+                job.CountDown = null!;
+            }
+            foreach (var job in plainJobs)
+            {
+                job.Memory1 = default;
+                job.Memory2 = default;
+                job.Memory3 = default;
+                job.Memory4 = default;
+                job.Memory5 = default;
+                job.Action = null!;
+                job.Uniform = default!;
+                job.CountDown = null!;
+            }
             JobPool<UniformDualWork<U, C0, C1, C2, C3, C4>>.Return(dualJobs);
             JobPool<UniformWork<U, C0, C1, C2, C3, C4>>.Return(plainJobs);
             Workloads.Rethrow(faults);
@@ -4079,8 +4376,6 @@ namespace fennecs
                 return sum;
             }
         }
-
-        private static readonly ComponentAction<C0, C1, C2, C3, C4> NoOp = static (ref C0 _, ref C1 _, ref C2 _, ref C3 _, ref C4 _) => { };
 
         private bool HasWildcards => Stream.StreamTypes.Any(type => type.isWildcard);
 

--- a/src/fennecs/generators/FilteredStream.tt
+++ b/src/fennecs/generators/FilteredStream.tt
@@ -384,6 +384,7 @@ namespace fennecs
 
             using var countdown = new CountdownEvent(initialCount: 1);
             using var jobs = PooledList<DualWork<<#= types #>>>.Rent();
+            FilterDelegate<<#= types #>> pass = Pass;
 
             foreach (var table in Archetypes)
             {
@@ -407,8 +408,8 @@ namespace fennecs
                         job.Memory<#= i + 1 #> = s<#= i #>.AsMemory(start, length);
 <# } #>
                         job.Included = action;
-                        job.Excluded = NoOp;
-                        job.Pass = Pass;
+                        job.Excluded = null;
+                        job.Pass = pass;
                         job.CountDown = countdown;
                         jobs.Add(job);
 
@@ -421,6 +422,14 @@ namespace fennecs
 
             List<Exception>? faults = null;
             Workloads.CollectFaults(ref faults, jobs);
+            foreach (var job in jobs)
+            {
+<# for (var i = 0; i < n; i++) { #>                job.Memory<#= i + 1 #> = default;
+<# } #>                job.Pass = null!;
+                job.Included = null!;
+                job.Excluded = null;
+                job.CountDown = null!;
+            }
             JobPool<DualWork<<#= types #>>>.Return(jobs);
             Workloads.Rethrow(faults);
         }
@@ -435,8 +444,7 @@ namespace fennecs
 
             using var countdown = new CountdownEvent(initialCount: 1);
             using var jobs = PooledList<UniformDualWork<U, <#= types #>>>.Rent();
-
-            UniformComponentAction<U, <#= types #>> noOp = static (U _, <#= FormatList(n, "ref C{0} _") #>) => { };
+            FilterDelegate<<#= types #>> pass = Pass;
 
             foreach (var table in Archetypes)
             {
@@ -460,8 +468,8 @@ namespace fennecs
                         job.Memory<#= i + 1 #> = s<#= i #>.AsMemory(start, length);
 <# } #>
                         job.Included = action;
-                        job.Excluded = noOp;
-                        job.Pass = Pass;
+                        job.Excluded = null;
+                        job.Pass = pass;
                         job.Uniform = uniform;
                         job.CountDown = countdown;
                         jobs.Add(job);
@@ -475,6 +483,15 @@ namespace fennecs
 
             List<Exception>? faults = null;
             Workloads.CollectFaults(ref faults, jobs);
+            foreach (var job in jobs)
+            {
+<# for (var i = 0; i < n; i++) { #>                job.Memory<#= i + 1 #> = default;
+<# } #>                job.Pass = null!;
+                job.Included = null!;
+                job.Excluded = null;
+                job.Uniform = default!;
+                job.CountDown = null!;
+            }
             JobPool<UniformDualWork<U, <#= types #>>>.Return(jobs);
             Workloads.Rethrow(faults);
         }
@@ -501,6 +518,7 @@ namespace fennecs
             using var countdown = new CountdownEvent(initialCount: 1);
             using var dualJobs = PooledList<DualWork<<#= types #>>>.Rent();
             using var plainJobs = PooledList<Work<<#= types #>>>.Rent();
+            FilterDelegate<<#= types #>> pass = Pass;
 
             foreach (var table in Archetypes)
             {
@@ -527,7 +545,7 @@ namespace fennecs
 <# } #>
                             job.Included = included;
                             job.Excluded = excluded;
-                            job.Pass = Pass;
+                            job.Pass = pass;
                             job.CountDown = countdown;
                             dualJobs.Add(job);
 
@@ -554,6 +572,20 @@ namespace fennecs
             List<Exception>? faults = null;
             Workloads.CollectFaults(ref faults, dualJobs);
             Workloads.CollectFaults(ref faults, plainJobs);
+            foreach (var job in dualJobs)
+            {
+<# for (var i = 0; i < n; i++) { #>                job.Memory<#= i + 1 #> = default;
+<# } #>                job.Pass = null!;
+                job.Included = null!;
+                job.Excluded = null;
+                job.CountDown = null!;
+            }
+            foreach (var job in plainJobs)
+            {
+<# for (var i = 0; i < n; i++) { #>                job.Memory<#= i + 1 #> = default;
+<# } #>                job.Action = null!;
+                job.CountDown = null!;
+            }
             JobPool<DualWork<<#= types #>>>.Return(dualJobs);
             JobPool<Work<<#= types #>>>.Return(plainJobs);
             Workloads.Rethrow(faults);
@@ -570,6 +602,7 @@ namespace fennecs
             using var countdown = new CountdownEvent(initialCount: 1);
             using var dualJobs = PooledList<UniformDualWork<U, <#= types #>>>.Rent();
             using var plainJobs = PooledList<UniformWork<U, <#= types #>>>.Rent();
+            FilterDelegate<<#= types #>> pass = Pass;
 
             foreach (var table in Archetypes)
             {
@@ -596,7 +629,7 @@ namespace fennecs
 <# } #>
                             job.Included = included;
                             job.Excluded = excluded;
-                            job.Pass = Pass;
+                            job.Pass = pass;
                             job.Uniform = uniform;
                             job.CountDown = countdown;
                             dualJobs.Add(job);
@@ -625,6 +658,22 @@ namespace fennecs
             List<Exception>? faults = null;
             Workloads.CollectFaults(ref faults, dualJobs);
             Workloads.CollectFaults(ref faults, plainJobs);
+            foreach (var job in dualJobs)
+            {
+<# for (var i = 0; i < n; i++) { #>                job.Memory<#= i + 1 #> = default;
+<# } #>                job.Pass = null!;
+                job.Included = null!;
+                job.Excluded = null;
+                job.Uniform = default!;
+                job.CountDown = null!;
+            }
+            foreach (var job in plainJobs)
+            {
+<# for (var i = 0; i < n; i++) { #>                job.Memory<#= i + 1 #> = default;
+<# } #>                job.Action = null!;
+                job.Uniform = default!;
+                job.CountDown = null!;
+            }
             JobPool<UniformDualWork<U, <#= types #>>>.Return(dualJobs);
             JobPool<UniformWork<U, <#= types #>>>.Return(plainJobs);
             Workloads.Rethrow(faults);
@@ -845,8 +894,6 @@ namespace fennecs
                 return sum;
             }
         }
-
-        private static readonly ComponentAction<<#= types #>> NoOp = static (<#= FormatList(n, "ref C{0} _") #>) => { };
 
         private bool HasWildcards => Stream.StreamTypes.Any(type => type.isWildcard);
 

--- a/src/fennecs/generators/Stream.generated.cs
+++ b/src/fennecs/generators/Stream.generated.cs
@@ -165,6 +165,14 @@ namespace fennecs
 
             using var countdown = new CountdownEvent(initialCount: 1);
             using var jobs = PooledList<Work<C0>>.Rent();
+            var segment = 0;
+            var workerLimit = Concurrency + 1; // Allow the rounding remainder without batching the dense case.
+            var expectedSegments = 0;
+            foreach (var table in Archetypes)
+            {
+                expectedSegments += table.Count / chunkSize + Math.Sign(table.Count % chunkSize);
+            }
+            var batchSegments = expectedSegments > workerLimit;
 
             foreach (var table in Archetypes)
             {
@@ -177,26 +185,56 @@ namespace fennecs
                 {
                     for (var chunk = 0; chunk < partitions; chunk++)
                     {
-                        countdown.AddCount();
                         var start = chunk * chunkSize;
                         var length = Math.Min(chunkSize, count - start);
 
                         var s0 = join.Select;
-                        var job = JobPool<Work<C0>>.Rent();
-                        job.Memory1 = s0.AsMemory(start,length);
-                        job.Action = action;
-                        job.CountDown = countdown;
-                        jobs.Add(job);
-
-                        ThreadPool.UnsafeQueueUserWorkItem(job, true);
+                        Work<C0> job;
+                        if (!batchSegments || jobs.Count < workerLimit)
+                        {
+                            job = JobPool<Work<C0>>.Rent();
+                            job.Memory1 = s0.AsMemory(start, length);
+                            job.Action = action;
+                            job.CountDown = countdown;
+                            jobs.Add(job);
+                            if (!batchSegments)
+                            {
+                                countdown.AddCount();
+                                ThreadPool.UnsafeQueueUserWorkItem(job, true);
+                            }
+                        }
+                        else
+                        {
+                            job = jobs[segment % jobs.Count];
+                            if (job.Segments is null)
+                            {
+                                job.Segments = PooledList<Memory<C0>>.Rent();
+                                job.Segments.Add(job.Memory1);
+                            }
+                            job.Segments.Add(s0.AsMemory(start, length));
+                        }
+                        segment++;
                     }
                 } while (join.Iterate());
+            }
+            if (batchSegments) foreach (var job in jobs)
+            {
+                countdown.AddCount();
+                ThreadPool.UnsafeQueueUserWorkItem(job, true);
             }
             countdown.Signal();
             countdown.Wait();
 
             List<Exception>? faults = null;
             Workloads.CollectFaults(ref faults, jobs);
+            foreach (var job in jobs)
+            {
+                job.Segments?.Dispose();
+                job.Segments = null;
+                job.Memory1 = default;
+                job.Action = null!;
+                job.CountDown = null!;
+            }
             JobPool<Work<C0>>.Return(jobs);
             Workloads.Rethrow(faults);
         }
@@ -211,6 +249,14 @@ namespace fennecs
 
             using var countdown = new CountdownEvent(initialCount: 1);
             using var jobs = PooledList<UniformWork<U, C0>>.Rent();
+            var segment = 0;
+            var workerLimit = Concurrency + 1; // Allow the rounding remainder without batching the dense case.
+            var expectedSegments = 0;
+            foreach (var table in Archetypes)
+            {
+                expectedSegments += table.Count / chunkSize + Math.Sign(table.Count % chunkSize);
+            }
+            var batchSegments = expectedSegments > workerLimit;
 
             foreach (var table in Archetypes)
             {
@@ -223,27 +269,58 @@ namespace fennecs
                 {
                     for (var chunk = 0; chunk < partitions; chunk++)
                     {
-                        countdown.AddCount();
                         var start = chunk * chunkSize;
                         var length = Math.Min(chunkSize, count - start);
 
                         var s0 = join.Select;
-                        var job = JobPool<UniformWork<U, C0>>.Rent();
-                        job.Memory1 = s0.AsMemory(start,length);
-                        job.Action = action;
-                        job.Uniform = uniform;
-                        job.CountDown = countdown;
-                        jobs.Add(job);
-
-                        ThreadPool.UnsafeQueueUserWorkItem(job, true);
+                        UniformWork<U, C0> job;
+                        if (!batchSegments || jobs.Count < workerLimit)
+                        {
+                            job = JobPool<UniformWork<U, C0>>.Rent();
+                            job.Memory1 = s0.AsMemory(start, length);
+                            job.Action = action;
+                            job.Uniform = uniform;
+                            job.CountDown = countdown;
+                            jobs.Add(job);
+                            if (!batchSegments)
+                            {
+                                countdown.AddCount();
+                                ThreadPool.UnsafeQueueUserWorkItem(job, true);
+                            }
+                        }
+                        else
+                        {
+                            job = jobs[segment % jobs.Count];
+                            if (job.Segments is null)
+                            {
+                                job.Segments = PooledList<Memory<C0>>.Rent();
+                                job.Segments.Add(job.Memory1);
+                            }
+                            job.Segments.Add(s0.AsMemory(start, length));
+                        }
+                        segment++;
                     }
                 } while (join.Iterate());
+            }
+            if (batchSegments) foreach (var job in jobs)
+            {
+                countdown.AddCount();
+                ThreadPool.UnsafeQueueUserWorkItem(job, true);
             }
             countdown.Signal();
             countdown.Wait();
 
             List<Exception>? faults = null;
             Workloads.CollectFaults(ref faults, jobs);
+            foreach (var job in jobs)
+            {
+                job.Segments?.Dispose();
+                job.Segments = null;
+                job.Memory1 = default;
+                job.Action = null!;
+                job.Uniform = default!;
+                job.CountDown = null!;
+            }
             JobPool<UniformWork<U, C0>>.Return(jobs);
             Workloads.Rethrow(faults);
         }
@@ -548,6 +625,14 @@ namespace fennecs
 
             using var countdown = new CountdownEvent(initialCount: 1);
             using var jobs = PooledList<Work<C0, C1>>.Rent();
+            var segment = 0;
+            var workerLimit = Concurrency + 1; // Allow the rounding remainder without batching the dense case.
+            var expectedSegments = 0;
+            foreach (var table in Archetypes)
+            {
+                expectedSegments += table.Count / chunkSize + Math.Sign(table.Count % chunkSize);
+            }
+            var batchSegments = expectedSegments > workerLimit;
 
             foreach (var table in Archetypes)
             {
@@ -560,27 +645,58 @@ namespace fennecs
                 {
                     for (var chunk = 0; chunk < partitions; chunk++)
                     {
-                        countdown.AddCount();
                         var start = chunk * chunkSize;
                         var length = Math.Min(chunkSize, count - start);
 
                         var (s0, s1) = join.Select;
-                        var job = JobPool<Work<C0, C1>>.Rent();
-                        job.Memory1 = s0.AsMemory(start,length);
-                        job.Memory2 = s1.AsMemory(start,length);
-                        job.Action = action;
-                        job.CountDown = countdown;
-                        jobs.Add(job);
-
-                        ThreadPool.UnsafeQueueUserWorkItem(job, true);
+                        Work<C0, C1> job;
+                        if (!batchSegments || jobs.Count < workerLimit)
+                        {
+                            job = JobPool<Work<C0, C1>>.Rent();
+                            job.Memory1 = s0.AsMemory(start, length);
+                            job.Memory2 = s1.AsMemory(start, length);
+                            job.Action = action;
+                            job.CountDown = countdown;
+                            jobs.Add(job);
+                            if (!batchSegments)
+                            {
+                                countdown.AddCount();
+                                ThreadPool.UnsafeQueueUserWorkItem(job, true);
+                            }
+                        }
+                        else
+                        {
+                            job = jobs[segment % jobs.Count];
+                            if (job.Segments is null)
+                            {
+                                job.Segments = PooledList<(Memory<C0>, Memory<C1>)>.Rent();
+                                job.Segments.Add((job.Memory1, job.Memory2));
+                            }
+                            job.Segments.Add((s0.AsMemory(start, length), s1.AsMemory(start, length)));
+                        }
+                        segment++;
                     }
                 } while (join.Iterate());
+            }
+            if (batchSegments) foreach (var job in jobs)
+            {
+                countdown.AddCount();
+                ThreadPool.UnsafeQueueUserWorkItem(job, true);
             }
             countdown.Signal();
             countdown.Wait();
 
             List<Exception>? faults = null;
             Workloads.CollectFaults(ref faults, jobs);
+            foreach (var job in jobs)
+            {
+                job.Segments?.Dispose();
+                job.Segments = null;
+                job.Memory1 = default;
+                job.Memory2 = default;
+                job.Action = null!;
+                job.CountDown = null!;
+            }
             JobPool<Work<C0, C1>>.Return(jobs);
             Workloads.Rethrow(faults);
         }
@@ -595,6 +711,14 @@ namespace fennecs
 
             using var countdown = new CountdownEvent(initialCount: 1);
             using var jobs = PooledList<UniformWork<U, C0, C1>>.Rent();
+            var segment = 0;
+            var workerLimit = Concurrency + 1; // Allow the rounding remainder without batching the dense case.
+            var expectedSegments = 0;
+            foreach (var table in Archetypes)
+            {
+                expectedSegments += table.Count / chunkSize + Math.Sign(table.Count % chunkSize);
+            }
+            var batchSegments = expectedSegments > workerLimit;
 
             foreach (var table in Archetypes)
             {
@@ -607,28 +731,60 @@ namespace fennecs
                 {
                     for (var chunk = 0; chunk < partitions; chunk++)
                     {
-                        countdown.AddCount();
                         var start = chunk * chunkSize;
                         var length = Math.Min(chunkSize, count - start);
 
                         var (s0, s1) = join.Select;
-                        var job = JobPool<UniformWork<U, C0, C1>>.Rent();
-                        job.Memory1 = s0.AsMemory(start,length);
-                        job.Memory2 = s1.AsMemory(start,length);
-                        job.Action = action;
-                        job.Uniform = uniform;
-                        job.CountDown = countdown;
-                        jobs.Add(job);
-
-                        ThreadPool.UnsafeQueueUserWorkItem(job, true);
+                        UniformWork<U, C0, C1> job;
+                        if (!batchSegments || jobs.Count < workerLimit)
+                        {
+                            job = JobPool<UniformWork<U, C0, C1>>.Rent();
+                            job.Memory1 = s0.AsMemory(start, length);
+                            job.Memory2 = s1.AsMemory(start, length);
+                            job.Action = action;
+                            job.Uniform = uniform;
+                            job.CountDown = countdown;
+                            jobs.Add(job);
+                            if (!batchSegments)
+                            {
+                                countdown.AddCount();
+                                ThreadPool.UnsafeQueueUserWorkItem(job, true);
+                            }
+                        }
+                        else
+                        {
+                            job = jobs[segment % jobs.Count];
+                            if (job.Segments is null)
+                            {
+                                job.Segments = PooledList<(Memory<C0>, Memory<C1>)>.Rent();
+                                job.Segments.Add((job.Memory1, job.Memory2));
+                            }
+                            job.Segments.Add((s0.AsMemory(start, length), s1.AsMemory(start, length)));
+                        }
+                        segment++;
                     }
                 } while (join.Iterate());
+            }
+            if (batchSegments) foreach (var job in jobs)
+            {
+                countdown.AddCount();
+                ThreadPool.UnsafeQueueUserWorkItem(job, true);
             }
             countdown.Signal();
             countdown.Wait();
 
             List<Exception>? faults = null;
             Workloads.CollectFaults(ref faults, jobs);
+            foreach (var job in jobs)
+            {
+                job.Segments?.Dispose();
+                job.Segments = null;
+                job.Memory1 = default;
+                job.Memory2 = default;
+                job.Action = null!;
+                job.Uniform = default!;
+                job.CountDown = null!;
+            }
             JobPool<UniformWork<U, C0, C1>>.Return(jobs);
             Workloads.Rethrow(faults);
         }
@@ -955,6 +1111,14 @@ namespace fennecs
 
             using var countdown = new CountdownEvent(initialCount: 1);
             using var jobs = PooledList<Work<C0, C1, C2>>.Rent();
+            var segment = 0;
+            var workerLimit = Concurrency + 1; // Allow the rounding remainder without batching the dense case.
+            var expectedSegments = 0;
+            foreach (var table in Archetypes)
+            {
+                expectedSegments += table.Count / chunkSize + Math.Sign(table.Count % chunkSize);
+            }
+            var batchSegments = expectedSegments > workerLimit;
 
             foreach (var table in Archetypes)
             {
@@ -967,28 +1131,60 @@ namespace fennecs
                 {
                     for (var chunk = 0; chunk < partitions; chunk++)
                     {
-                        countdown.AddCount();
                         var start = chunk * chunkSize;
                         var length = Math.Min(chunkSize, count - start);
 
                         var (s0, s1, s2) = join.Select;
-                        var job = JobPool<Work<C0, C1, C2>>.Rent();
-                        job.Memory1 = s0.AsMemory(start,length);
-                        job.Memory2 = s1.AsMemory(start,length);
-                        job.Memory3 = s2.AsMemory(start,length);
-                        job.Action = action;
-                        job.CountDown = countdown;
-                        jobs.Add(job);
-
-                        ThreadPool.UnsafeQueueUserWorkItem(job, true);
+                        Work<C0, C1, C2> job;
+                        if (!batchSegments || jobs.Count < workerLimit)
+                        {
+                            job = JobPool<Work<C0, C1, C2>>.Rent();
+                            job.Memory1 = s0.AsMemory(start, length);
+                            job.Memory2 = s1.AsMemory(start, length);
+                            job.Memory3 = s2.AsMemory(start, length);
+                            job.Action = action;
+                            job.CountDown = countdown;
+                            jobs.Add(job);
+                            if (!batchSegments)
+                            {
+                                countdown.AddCount();
+                                ThreadPool.UnsafeQueueUserWorkItem(job, true);
+                            }
+                        }
+                        else
+                        {
+                            job = jobs[segment % jobs.Count];
+                            if (job.Segments is null)
+                            {
+                                job.Segments = PooledList<(Memory<C0>, Memory<C1>, Memory<C2>)>.Rent();
+                                job.Segments.Add((job.Memory1, job.Memory2, job.Memory3));
+                            }
+                            job.Segments.Add((s0.AsMemory(start, length), s1.AsMemory(start, length), s2.AsMemory(start, length)));
+                        }
+                        segment++;
                     }
                 } while (join.Iterate());
+            }
+            if (batchSegments) foreach (var job in jobs)
+            {
+                countdown.AddCount();
+                ThreadPool.UnsafeQueueUserWorkItem(job, true);
             }
             countdown.Signal();
             countdown.Wait();
 
             List<Exception>? faults = null;
             Workloads.CollectFaults(ref faults, jobs);
+            foreach (var job in jobs)
+            {
+                job.Segments?.Dispose();
+                job.Segments = null;
+                job.Memory1 = default;
+                job.Memory2 = default;
+                job.Memory3 = default;
+                job.Action = null!;
+                job.CountDown = null!;
+            }
             JobPool<Work<C0, C1, C2>>.Return(jobs);
             Workloads.Rethrow(faults);
         }
@@ -1003,6 +1199,14 @@ namespace fennecs
 
             using var countdown = new CountdownEvent(initialCount: 1);
             using var jobs = PooledList<UniformWork<U, C0, C1, C2>>.Rent();
+            var segment = 0;
+            var workerLimit = Concurrency + 1; // Allow the rounding remainder without batching the dense case.
+            var expectedSegments = 0;
+            foreach (var table in Archetypes)
+            {
+                expectedSegments += table.Count / chunkSize + Math.Sign(table.Count % chunkSize);
+            }
+            var batchSegments = expectedSegments > workerLimit;
 
             foreach (var table in Archetypes)
             {
@@ -1015,29 +1219,62 @@ namespace fennecs
                 {
                     for (var chunk = 0; chunk < partitions; chunk++)
                     {
-                        countdown.AddCount();
                         var start = chunk * chunkSize;
                         var length = Math.Min(chunkSize, count - start);
 
                         var (s0, s1, s2) = join.Select;
-                        var job = JobPool<UniformWork<U, C0, C1, C2>>.Rent();
-                        job.Memory1 = s0.AsMemory(start,length);
-                        job.Memory2 = s1.AsMemory(start,length);
-                        job.Memory3 = s2.AsMemory(start,length);
-                        job.Action = action;
-                        job.Uniform = uniform;
-                        job.CountDown = countdown;
-                        jobs.Add(job);
-
-                        ThreadPool.UnsafeQueueUserWorkItem(job, true);
+                        UniformWork<U, C0, C1, C2> job;
+                        if (!batchSegments || jobs.Count < workerLimit)
+                        {
+                            job = JobPool<UniformWork<U, C0, C1, C2>>.Rent();
+                            job.Memory1 = s0.AsMemory(start, length);
+                            job.Memory2 = s1.AsMemory(start, length);
+                            job.Memory3 = s2.AsMemory(start, length);
+                            job.Action = action;
+                            job.Uniform = uniform;
+                            job.CountDown = countdown;
+                            jobs.Add(job);
+                            if (!batchSegments)
+                            {
+                                countdown.AddCount();
+                                ThreadPool.UnsafeQueueUserWorkItem(job, true);
+                            }
+                        }
+                        else
+                        {
+                            job = jobs[segment % jobs.Count];
+                            if (job.Segments is null)
+                            {
+                                job.Segments = PooledList<(Memory<C0>, Memory<C1>, Memory<C2>)>.Rent();
+                                job.Segments.Add((job.Memory1, job.Memory2, job.Memory3));
+                            }
+                            job.Segments.Add((s0.AsMemory(start, length), s1.AsMemory(start, length), s2.AsMemory(start, length)));
+                        }
+                        segment++;
                     }
                 } while (join.Iterate());
+            }
+            if (batchSegments) foreach (var job in jobs)
+            {
+                countdown.AddCount();
+                ThreadPool.UnsafeQueueUserWorkItem(job, true);
             }
             countdown.Signal();
             countdown.Wait();
 
             List<Exception>? faults = null;
             Workloads.CollectFaults(ref faults, jobs);
+            foreach (var job in jobs)
+            {
+                job.Segments?.Dispose();
+                job.Segments = null;
+                job.Memory1 = default;
+                job.Memory2 = default;
+                job.Memory3 = default;
+                job.Action = null!;
+                job.Uniform = default!;
+                job.CountDown = null!;
+            }
             JobPool<UniformWork<U, C0, C1, C2>>.Return(jobs);
             Workloads.Rethrow(faults);
         }
@@ -1386,6 +1623,14 @@ namespace fennecs
 
             using var countdown = new CountdownEvent(initialCount: 1);
             using var jobs = PooledList<Work<C0, C1, C2, C3>>.Rent();
+            var segment = 0;
+            var workerLimit = Concurrency + 1; // Allow the rounding remainder without batching the dense case.
+            var expectedSegments = 0;
+            foreach (var table in Archetypes)
+            {
+                expectedSegments += table.Count / chunkSize + Math.Sign(table.Count % chunkSize);
+            }
+            var batchSegments = expectedSegments > workerLimit;
 
             foreach (var table in Archetypes)
             {
@@ -1398,29 +1643,62 @@ namespace fennecs
                 {
                     for (var chunk = 0; chunk < partitions; chunk++)
                     {
-                        countdown.AddCount();
                         var start = chunk * chunkSize;
                         var length = Math.Min(chunkSize, count - start);
 
                         var (s0, s1, s2, s3) = join.Select;
-                        var job = JobPool<Work<C0, C1, C2, C3>>.Rent();
-                        job.Memory1 = s0.AsMemory(start,length);
-                        job.Memory2 = s1.AsMemory(start,length);
-                        job.Memory3 = s2.AsMemory(start,length);
-                        job.Memory4 = s3.AsMemory(start,length);
-                        job.Action = action;
-                        job.CountDown = countdown;
-                        jobs.Add(job);
-
-                        ThreadPool.UnsafeQueueUserWorkItem(job, true);
+                        Work<C0, C1, C2, C3> job;
+                        if (!batchSegments || jobs.Count < workerLimit)
+                        {
+                            job = JobPool<Work<C0, C1, C2, C3>>.Rent();
+                            job.Memory1 = s0.AsMemory(start, length);
+                            job.Memory2 = s1.AsMemory(start, length);
+                            job.Memory3 = s2.AsMemory(start, length);
+                            job.Memory4 = s3.AsMemory(start, length);
+                            job.Action = action;
+                            job.CountDown = countdown;
+                            jobs.Add(job);
+                            if (!batchSegments)
+                            {
+                                countdown.AddCount();
+                                ThreadPool.UnsafeQueueUserWorkItem(job, true);
+                            }
+                        }
+                        else
+                        {
+                            job = jobs[segment % jobs.Count];
+                            if (job.Segments is null)
+                            {
+                                job.Segments = PooledList<(Memory<C0>, Memory<C1>, Memory<C2>, Memory<C3>)>.Rent();
+                                job.Segments.Add((job.Memory1, job.Memory2, job.Memory3, job.Memory4));
+                            }
+                            job.Segments.Add((s0.AsMemory(start, length), s1.AsMemory(start, length), s2.AsMemory(start, length), s3.AsMemory(start, length)));
+                        }
+                        segment++;
                     }
                 } while (join.Iterate());
+            }
+            if (batchSegments) foreach (var job in jobs)
+            {
+                countdown.AddCount();
+                ThreadPool.UnsafeQueueUserWorkItem(job, true);
             }
             countdown.Signal();
             countdown.Wait();
 
             List<Exception>? faults = null;
             Workloads.CollectFaults(ref faults, jobs);
+            foreach (var job in jobs)
+            {
+                job.Segments?.Dispose();
+                job.Segments = null;
+                job.Memory1 = default;
+                job.Memory2 = default;
+                job.Memory3 = default;
+                job.Memory4 = default;
+                job.Action = null!;
+                job.CountDown = null!;
+            }
             JobPool<Work<C0, C1, C2, C3>>.Return(jobs);
             Workloads.Rethrow(faults);
         }
@@ -1435,6 +1713,14 @@ namespace fennecs
 
             using var countdown = new CountdownEvent(initialCount: 1);
             using var jobs = PooledList<UniformWork<U, C0, C1, C2, C3>>.Rent();
+            var segment = 0;
+            var workerLimit = Concurrency + 1; // Allow the rounding remainder without batching the dense case.
+            var expectedSegments = 0;
+            foreach (var table in Archetypes)
+            {
+                expectedSegments += table.Count / chunkSize + Math.Sign(table.Count % chunkSize);
+            }
+            var batchSegments = expectedSegments > workerLimit;
 
             foreach (var table in Archetypes)
             {
@@ -1447,30 +1733,64 @@ namespace fennecs
                 {
                     for (var chunk = 0; chunk < partitions; chunk++)
                     {
-                        countdown.AddCount();
                         var start = chunk * chunkSize;
                         var length = Math.Min(chunkSize, count - start);
 
                         var (s0, s1, s2, s3) = join.Select;
-                        var job = JobPool<UniformWork<U, C0, C1, C2, C3>>.Rent();
-                        job.Memory1 = s0.AsMemory(start,length);
-                        job.Memory2 = s1.AsMemory(start,length);
-                        job.Memory3 = s2.AsMemory(start,length);
-                        job.Memory4 = s3.AsMemory(start,length);
-                        job.Action = action;
-                        job.Uniform = uniform;
-                        job.CountDown = countdown;
-                        jobs.Add(job);
-
-                        ThreadPool.UnsafeQueueUserWorkItem(job, true);
+                        UniformWork<U, C0, C1, C2, C3> job;
+                        if (!batchSegments || jobs.Count < workerLimit)
+                        {
+                            job = JobPool<UniformWork<U, C0, C1, C2, C3>>.Rent();
+                            job.Memory1 = s0.AsMemory(start, length);
+                            job.Memory2 = s1.AsMemory(start, length);
+                            job.Memory3 = s2.AsMemory(start, length);
+                            job.Memory4 = s3.AsMemory(start, length);
+                            job.Action = action;
+                            job.Uniform = uniform;
+                            job.CountDown = countdown;
+                            jobs.Add(job);
+                            if (!batchSegments)
+                            {
+                                countdown.AddCount();
+                                ThreadPool.UnsafeQueueUserWorkItem(job, true);
+                            }
+                        }
+                        else
+                        {
+                            job = jobs[segment % jobs.Count];
+                            if (job.Segments is null)
+                            {
+                                job.Segments = PooledList<(Memory<C0>, Memory<C1>, Memory<C2>, Memory<C3>)>.Rent();
+                                job.Segments.Add((job.Memory1, job.Memory2, job.Memory3, job.Memory4));
+                            }
+                            job.Segments.Add((s0.AsMemory(start, length), s1.AsMemory(start, length), s2.AsMemory(start, length), s3.AsMemory(start, length)));
+                        }
+                        segment++;
                     }
                 } while (join.Iterate());
+            }
+            if (batchSegments) foreach (var job in jobs)
+            {
+                countdown.AddCount();
+                ThreadPool.UnsafeQueueUserWorkItem(job, true);
             }
             countdown.Signal();
             countdown.Wait();
 
             List<Exception>? faults = null;
             Workloads.CollectFaults(ref faults, jobs);
+            foreach (var job in jobs)
+            {
+                job.Segments?.Dispose();
+                job.Segments = null;
+                job.Memory1 = default;
+                job.Memory2 = default;
+                job.Memory3 = default;
+                job.Memory4 = default;
+                job.Action = null!;
+                job.Uniform = default!;
+                job.CountDown = null!;
+            }
             JobPool<UniformWork<U, C0, C1, C2, C3>>.Return(jobs);
             Workloads.Rethrow(faults);
         }
@@ -1841,6 +2161,14 @@ namespace fennecs
 
             using var countdown = new CountdownEvent(initialCount: 1);
             using var jobs = PooledList<Work<C0, C1, C2, C3, C4>>.Rent();
+            var segment = 0;
+            var workerLimit = Concurrency + 1; // Allow the rounding remainder without batching the dense case.
+            var expectedSegments = 0;
+            foreach (var table in Archetypes)
+            {
+                expectedSegments += table.Count / chunkSize + Math.Sign(table.Count % chunkSize);
+            }
+            var batchSegments = expectedSegments > workerLimit;
 
             foreach (var table in Archetypes)
             {
@@ -1853,30 +2181,64 @@ namespace fennecs
                 {
                     for (var chunk = 0; chunk < partitions; chunk++)
                     {
-                        countdown.AddCount();
                         var start = chunk * chunkSize;
                         var length = Math.Min(chunkSize, count - start);
 
                         var (s0, s1, s2, s3, s4) = join.Select;
-                        var job = JobPool<Work<C0, C1, C2, C3, C4>>.Rent();
-                        job.Memory1 = s0.AsMemory(start,length);
-                        job.Memory2 = s1.AsMemory(start,length);
-                        job.Memory3 = s2.AsMemory(start,length);
-                        job.Memory4 = s3.AsMemory(start,length);
-                        job.Memory5 = s4.AsMemory(start,length);
-                        job.Action = action;
-                        job.CountDown = countdown;
-                        jobs.Add(job);
-
-                        ThreadPool.UnsafeQueueUserWorkItem(job, true);
+                        Work<C0, C1, C2, C3, C4> job;
+                        if (!batchSegments || jobs.Count < workerLimit)
+                        {
+                            job = JobPool<Work<C0, C1, C2, C3, C4>>.Rent();
+                            job.Memory1 = s0.AsMemory(start, length);
+                            job.Memory2 = s1.AsMemory(start, length);
+                            job.Memory3 = s2.AsMemory(start, length);
+                            job.Memory4 = s3.AsMemory(start, length);
+                            job.Memory5 = s4.AsMemory(start, length);
+                            job.Action = action;
+                            job.CountDown = countdown;
+                            jobs.Add(job);
+                            if (!batchSegments)
+                            {
+                                countdown.AddCount();
+                                ThreadPool.UnsafeQueueUserWorkItem(job, true);
+                            }
+                        }
+                        else
+                        {
+                            job = jobs[segment % jobs.Count];
+                            if (job.Segments is null)
+                            {
+                                job.Segments = PooledList<(Memory<C0>, Memory<C1>, Memory<C2>, Memory<C3>, Memory<C4>)>.Rent();
+                                job.Segments.Add((job.Memory1, job.Memory2, job.Memory3, job.Memory4, job.Memory5));
+                            }
+                            job.Segments.Add((s0.AsMemory(start, length), s1.AsMemory(start, length), s2.AsMemory(start, length), s3.AsMemory(start, length), s4.AsMemory(start, length)));
+                        }
+                        segment++;
                     }
                 } while (join.Iterate());
+            }
+            if (batchSegments) foreach (var job in jobs)
+            {
+                countdown.AddCount();
+                ThreadPool.UnsafeQueueUserWorkItem(job, true);
             }
             countdown.Signal();
             countdown.Wait();
 
             List<Exception>? faults = null;
             Workloads.CollectFaults(ref faults, jobs);
+            foreach (var job in jobs)
+            {
+                job.Segments?.Dispose();
+                job.Segments = null;
+                job.Memory1 = default;
+                job.Memory2 = default;
+                job.Memory3 = default;
+                job.Memory4 = default;
+                job.Memory5 = default;
+                job.Action = null!;
+                job.CountDown = null!;
+            }
             JobPool<Work<C0, C1, C2, C3, C4>>.Return(jobs);
             Workloads.Rethrow(faults);
         }
@@ -1891,6 +2253,14 @@ namespace fennecs
 
             using var countdown = new CountdownEvent(initialCount: 1);
             using var jobs = PooledList<UniformWork<U, C0, C1, C2, C3, C4>>.Rent();
+            var segment = 0;
+            var workerLimit = Concurrency + 1; // Allow the rounding remainder without batching the dense case.
+            var expectedSegments = 0;
+            foreach (var table in Archetypes)
+            {
+                expectedSegments += table.Count / chunkSize + Math.Sign(table.Count % chunkSize);
+            }
+            var batchSegments = expectedSegments > workerLimit;
 
             foreach (var table in Archetypes)
             {
@@ -1903,31 +2273,66 @@ namespace fennecs
                 {
                     for (var chunk = 0; chunk < partitions; chunk++)
                     {
-                        countdown.AddCount();
                         var start = chunk * chunkSize;
                         var length = Math.Min(chunkSize, count - start);
 
                         var (s0, s1, s2, s3, s4) = join.Select;
-                        var job = JobPool<UniformWork<U, C0, C1, C2, C3, C4>>.Rent();
-                        job.Memory1 = s0.AsMemory(start,length);
-                        job.Memory2 = s1.AsMemory(start,length);
-                        job.Memory3 = s2.AsMemory(start,length);
-                        job.Memory4 = s3.AsMemory(start,length);
-                        job.Memory5 = s4.AsMemory(start,length);
-                        job.Action = action;
-                        job.Uniform = uniform;
-                        job.CountDown = countdown;
-                        jobs.Add(job);
-
-                        ThreadPool.UnsafeQueueUserWorkItem(job, true);
+                        UniformWork<U, C0, C1, C2, C3, C4> job;
+                        if (!batchSegments || jobs.Count < workerLimit)
+                        {
+                            job = JobPool<UniformWork<U, C0, C1, C2, C3, C4>>.Rent();
+                            job.Memory1 = s0.AsMemory(start, length);
+                            job.Memory2 = s1.AsMemory(start, length);
+                            job.Memory3 = s2.AsMemory(start, length);
+                            job.Memory4 = s3.AsMemory(start, length);
+                            job.Memory5 = s4.AsMemory(start, length);
+                            job.Action = action;
+                            job.Uniform = uniform;
+                            job.CountDown = countdown;
+                            jobs.Add(job);
+                            if (!batchSegments)
+                            {
+                                countdown.AddCount();
+                                ThreadPool.UnsafeQueueUserWorkItem(job, true);
+                            }
+                        }
+                        else
+                        {
+                            job = jobs[segment % jobs.Count];
+                            if (job.Segments is null)
+                            {
+                                job.Segments = PooledList<(Memory<C0>, Memory<C1>, Memory<C2>, Memory<C3>, Memory<C4>)>.Rent();
+                                job.Segments.Add((job.Memory1, job.Memory2, job.Memory3, job.Memory4, job.Memory5));
+                            }
+                            job.Segments.Add((s0.AsMemory(start, length), s1.AsMemory(start, length), s2.AsMemory(start, length), s3.AsMemory(start, length), s4.AsMemory(start, length)));
+                        }
+                        segment++;
                     }
                 } while (join.Iterate());
+            }
+            if (batchSegments) foreach (var job in jobs)
+            {
+                countdown.AddCount();
+                ThreadPool.UnsafeQueueUserWorkItem(job, true);
             }
             countdown.Signal();
             countdown.Wait();
 
             List<Exception>? faults = null;
             Workloads.CollectFaults(ref faults, jobs);
+            foreach (var job in jobs)
+            {
+                job.Segments?.Dispose();
+                job.Segments = null;
+                job.Memory1 = default;
+                job.Memory2 = default;
+                job.Memory3 = default;
+                job.Memory4 = default;
+                job.Memory5 = default;
+                job.Action = null!;
+                job.Uniform = default!;
+                job.CountDown = null!;
+            }
             JobPool<UniformWork<U, C0, C1, C2, C3, C4>>.Return(jobs);
             Workloads.Rethrow(faults);
         }

--- a/src/fennecs/generators/Stream.tt
+++ b/src/fennecs/generators/Stream.tt
@@ -57,6 +57,13 @@ namespace fennecs
     for (var n = 1; n <= maxArity; n++)
     {
         var types = GenTypeList(n);
+        var segmentType = n == 1 ? "Memory<C0>" : $"({FormatList(n, "Memory<C{0}>")})";
+        var segmentValue = n == 1
+            ? "s0.AsMemory(start, length)"
+            : $"({GenList("s", n, ", ", ".AsMemory(start, length)")})";
+        var initialSegmentValue = n == 1
+            ? "job.Memory1"
+            : $"({string.Join(", ", Enumerable.Range(1, n).Select(i => $"job.Memory{i}"))})";
 #>
     /// <summary>
     /// Auto-generated Stream with arity <#= n #>.
@@ -211,6 +218,14 @@ namespace fennecs
 
             using var countdown = new CountdownEvent(initialCount: 1);
             using var jobs = PooledList<Work<<#= types #>>>.Rent();
+            var segment = 0;
+            var workerLimit = Concurrency + 1; // Allow the rounding remainder without batching the dense case.
+            var expectedSegments = 0;
+            foreach (var table in Archetypes)
+            {
+                expectedSegments += table.Count / chunkSize + Math.Sign(table.Count % chunkSize);
+            }
+            var batchSegments = expectedSegments > workerLimit;
 
             foreach (var table in Archetypes)
             {
@@ -223,28 +238,57 @@ namespace fennecs
                 {
                     for (var chunk = 0; chunk < partitions; chunk++)
                     {
-                        countdown.AddCount();
                         var start = chunk * chunkSize;
                         var length = Math.Min(chunkSize, count - start);
 
                         var <#= (n > 1 ? "(" : "") + GenList("s",n) + (n > 1 ? ")" : "")  #> = join.Select;
-                        var job = JobPool<Work<<#= types #>>>.Rent();
-<# for (var i=0;i<n;i++){ #>
-                        job.Memory<#= i+1 #> = s<#= i #>.AsMemory(start,length);
+                        Work<<#= types #>> job;
+                        if (!batchSegments || jobs.Count < workerLimit)
+                        {
+                            job = JobPool<Work<<#= types #>>>.Rent();
+<# for (var i=0;i<n;i++){ #>                            job.Memory<#= i+1 #> = s<#= i #>.AsMemory(start, length);
 <# } #>
-                        job.Action = action;
-                        job.CountDown = countdown;
-                        jobs.Add(job);
-
-                        ThreadPool.UnsafeQueueUserWorkItem(job, true);
+                            job.Action = action;
+                            job.CountDown = countdown;
+                            jobs.Add(job);
+                            if (!batchSegments)
+                            {
+                                countdown.AddCount();
+                                ThreadPool.UnsafeQueueUserWorkItem(job, true);
+                            }
+                        }
+                        else
+                        {
+                            job = jobs[segment % jobs.Count];
+                            if (job.Segments is null)
+                            {
+                                job.Segments = PooledList<<#= segmentType #>>.Rent();
+                                job.Segments.Add(<#= initialSegmentValue #>);
+                            }
+                            job.Segments.Add(<#= segmentValue #>);
+                        }
+                        segment++;
                     }
                 } while (join.Iterate());
+            }
+            if (batchSegments) foreach (var job in jobs)
+            {
+                countdown.AddCount();
+                ThreadPool.UnsafeQueueUserWorkItem(job, true);
             }
             countdown.Signal();
             countdown.Wait();
 
             List<Exception>? faults = null;
             Workloads.CollectFaults(ref faults, jobs);
+            foreach (var job in jobs)
+            {
+                job.Segments?.Dispose();
+                job.Segments = null;
+<# for (var i=0;i<n;i++){ #>                job.Memory<#= i+1 #> = default;
+<# } #>                job.Action = null!;
+                job.CountDown = null!;
+            }
             JobPool<Work<<#= types #>>>.Return(jobs);
             Workloads.Rethrow(faults);
         }
@@ -259,6 +303,14 @@ namespace fennecs
 
             using var countdown = new CountdownEvent(initialCount: 1);
             using var jobs = PooledList<UniformWork<U, <#= types #>>>.Rent();
+            var segment = 0;
+            var workerLimit = Concurrency + 1; // Allow the rounding remainder without batching the dense case.
+            var expectedSegments = 0;
+            foreach (var table in Archetypes)
+            {
+                expectedSegments += table.Count / chunkSize + Math.Sign(table.Count % chunkSize);
+            }
+            var batchSegments = expectedSegments > workerLimit;
 
             foreach (var table in Archetypes)
             {
@@ -271,29 +323,59 @@ namespace fennecs
                 {
                     for (var chunk = 0; chunk < partitions; chunk++)
                     {
-                        countdown.AddCount();
                         var start = chunk * chunkSize;
                         var length = Math.Min(chunkSize, count - start);
 
                         var <#= (n > 1 ? "(" : "") + GenList("s",n) + (n > 1 ? ")" : "")  #> = join.Select;
-                        var job = JobPool<UniformWork<U, <#= types #>>>.Rent();
-<# for (var i=0;i<n;i++){ #>
-                        job.Memory<#= i+1 #> = s<#= i #>.AsMemory(start,length);
+                        UniformWork<U, <#= types #>> job;
+                        if (!batchSegments || jobs.Count < workerLimit)
+                        {
+                            job = JobPool<UniformWork<U, <#= types #>>>.Rent();
+<# for (var i=0;i<n;i++){ #>                            job.Memory<#= i+1 #> = s<#= i #>.AsMemory(start, length);
 <# } #>
-                        job.Action = action;
-                        job.Uniform = uniform;
-                        job.CountDown = countdown;
-                        jobs.Add(job);
-
-                        ThreadPool.UnsafeQueueUserWorkItem(job, true);
+                            job.Action = action;
+                            job.Uniform = uniform;
+                            job.CountDown = countdown;
+                            jobs.Add(job);
+                            if (!batchSegments)
+                            {
+                                countdown.AddCount();
+                                ThreadPool.UnsafeQueueUserWorkItem(job, true);
+                            }
+                        }
+                        else
+                        {
+                            job = jobs[segment % jobs.Count];
+                            if (job.Segments is null)
+                            {
+                                job.Segments = PooledList<<#= segmentType #>>.Rent();
+                                job.Segments.Add(<#= initialSegmentValue #>);
+                            }
+                            job.Segments.Add(<#= segmentValue #>);
+                        }
+                        segment++;
                     }
                 } while (join.Iterate());
+            }
+            if (batchSegments) foreach (var job in jobs)
+            {
+                countdown.AddCount();
+                ThreadPool.UnsafeQueueUserWorkItem(job, true);
             }
             countdown.Signal();
             countdown.Wait();
 
             List<Exception>? faults = null;
             Workloads.CollectFaults(ref faults, jobs);
+            foreach (var job in jobs)
+            {
+                job.Segments?.Dispose();
+                job.Segments = null;
+<# for (var i=0;i<n;i++){ #>                job.Memory<#= i+1 #> = default;
+<# } #>                job.Action = null!;
+                job.Uniform = default!;
+                job.CountDown = null!;
+            }
             JobPool<UniformWork<U, <#= types #>>>.Return(jobs);
             Workloads.Rethrow(faults);
         }


### PR DESCRIPTION
- Add direct storage binding for concrete stream expressions while preserving wildcard joins.
- Cap fragmented Stream.Job scheduling to reduce work items and allocations.
- Reduce filtered-job allocations and remove rejected-entity no-op dispatch.
- Preserve exception behavior across segmented workers.
- Add focused benchmarks and regression tests.

In the 1,024-archetype benchmark, no-op Job improved from 514 µs/12.9 KB/1,024 work items to 107 µs/800 B/23 work items. All 4,289 tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Round-robin work packaging with a worker-aware cap cuts over-scheduling on fragmented archetypes and speeds up hot-path dispatch. Concrete streams and joins bind directly to storage, and segmented worker faults now flatten and rethrow while letting other segments finish.

- **Performance**
  - Added round-robin segment packaging with a `Concurrency`-based cap to limit work items on fragmented archetypes.
  - Bound concrete stream expressions and `Cross.Join` directly to storage; wildcard joins remain for `Match.Any`.
  - Removed excluded-branch scheduling in `FilteredStream.Job` and trimmed pooled-job allocations.
  - Benchmarks added for stream binding, For/Job crossover, and filtered dispatch. No-op job (1,024 archetypes): 514 µs / 12.9 KB / 1,024 items → 107 µs / 800 B / 23 items.

- **Bug Fixes**
  - Flattened and rethrown worker exceptions across segments; other segments continue after a fault, with new regression tests.
  - Direct joins hold no pooled state; dispose is safe and does not touch pooled resources.

<sup>Written for commit 70816fdce6a680dc1ac94ff76f15160e7b8e48b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/outfox/fennecs/pull/50?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

